### PR TITLE
Standardised Message Types and AnteHandler Now Uses Route()

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -298,16 +298,16 @@ func NewIxoAnteHandler(app *ixoApp) sdk.AnteHandler {
 
 	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (_ sdk.Context, _ sdk.Result, abort bool) {
 		msg := tx.GetMsgs()[0]
-		switch msg.Type() {
-		case did.ModuleName:
+		switch msg.Route() {
+		case did.RouterKey:
 			return didAnteHandler(ctx, tx, false)
-		case project.ModuleName:
+		case project.RouterKey:
 			return projectAnteHandler(ctx, tx, false)
-		case bonddoc.ModuleName:
+		case bonddoc.RouterKey:
 			return bonddocAnteHandler(ctx, tx, false)
-		case bonds.ModuleName:
+		case bonds.RouterKey:
 			return bondsAnteHandler(ctx, tx, false)
-		case treasury.ModuleName:
+		case treasury.RouterKey:
 			return treasuryAnteHandler(ctx, tx, false)
 		default:
 			return cosmosAnteHandler(ctx, tx, false)

--- a/x/bonddoc/internal/types/keys.go
+++ b/x/bonddoc/internal/types/keys.go
@@ -7,8 +7,8 @@ import (
 const (
 	ModuleName   = "bonddoc"
 	StoreKey     = ModuleName
-	RouterKey    = StoreKey
-	QuerierRoute = RouterKey
+	RouterKey    = ModuleName
+	QuerierRoute = ModuleName
 )
 
 var (

--- a/x/bonddoc/internal/types/msgs.go
+++ b/x/bonddoc/internal/types/msgs.go
@@ -19,7 +19,7 @@ type MsgCreateBond struct {
 
 var _ sdk.Msg = MsgCreateBond{}
 
-func (msg MsgCreateBond) Type() string  { return ModuleName }
+func (msg MsgCreateBond) Type() string  { return "create-bond" }
 func (msg MsgCreateBond) Route() string { return RouterKey }
 func (msg MsgCreateBond) ValidateBasic() sdk.Error {
 	valid, err := CheckNotEmpty(msg.PubKey, "PubKey")
@@ -75,7 +75,7 @@ type MsgUpdateBondStatus struct {
 	Data      UpdateBondStatusDoc `json:"data" yaml:"data"`
 }
 
-func (msg MsgUpdateBondStatus) Type() string             { return ModuleName }
+func (msg MsgUpdateBondStatus) Type() string             { return "update-bond-status" }
 func (msg MsgUpdateBondStatus) Route() string            { return RouterKey }
 func (msg MsgUpdateBondStatus) ValidateBasic() sdk.Error { return nil }
 func (msg MsgUpdateBondStatus) GetSignBytes() []byte {

--- a/x/bonds/internal/types/msgs.go
+++ b/x/bonds/internal/types/msgs.go
@@ -123,7 +123,7 @@ func (msg MsgCreateBond) GetSigners() []sdk.AccAddress {
 
 func (msg MsgCreateBond) Route() string { return RouterKey }
 
-func (msg MsgCreateBond) Type() string { return ModuleName }
+func (msg MsgCreateBond) Type() string { return "create_bond" }
 
 type MsgEditBond struct { // signBytes should not be changed to sign_bytes because of ixo.types.DefaultTxDecoder
 	SignBytes              string  `json:"signBytes" yaml:"signBytes"`
@@ -201,7 +201,7 @@ func (msg MsgEditBond) GetSigners() []sdk.AccAddress {
 
 func (msg MsgEditBond) Route() string { return RouterKey }
 
-func (msg MsgEditBond) Type() string { return ModuleName }
+func (msg MsgEditBond) Type() string { return "edit_bond" }
 
 type MsgBuy struct { // signBytes should not be changed to sign_bytes because of ixo.types.DefaultTxDecoder
 	SignBytes string    `json:"signBytes" yaml:"signBytes"`
@@ -252,7 +252,7 @@ func (msg MsgBuy) GetSigners() []sdk.AccAddress {
 
 func (msg MsgBuy) Route() string { return RouterKey }
 
-func (msg MsgBuy) Type() string { return ModuleName }
+func (msg MsgBuy) Type() string { return "buy" }
 
 type MsgSell struct { // signBytes should not be changed to sign_bytes because of ixo.types.DefaultTxDecoder
 	SignBytes string   `json:"signBytes" yaml:"signBytes"`
@@ -300,7 +300,7 @@ func (msg MsgSell) GetSigners() []sdk.AccAddress {
 
 func (msg MsgSell) Route() string { return RouterKey }
 
-func (msg MsgSell) Type() string { return ModuleName }
+func (msg MsgSell) Type() string { return "sell" }
 
 type MsgSwap struct { // signBytes should not be changed to sign_bytes because of ixo.types.DefaultTxDecoder
 	SignBytes  string   `json:"signBytes" yaml:"signBytes"`
@@ -359,4 +359,4 @@ func (msg MsgSwap) GetSigners() []sdk.AccAddress {
 
 func (msg MsgSwap) Route() string { return RouterKey }
 
-func (msg MsgSwap) Type() string { return ModuleName }
+func (msg MsgSwap) Type() string { return "swap" }

--- a/x/did/internal/types/keys.go
+++ b/x/did/internal/types/keys.go
@@ -7,8 +7,8 @@ import (
 const (
 	ModuleName   = "did"
 	StoreKey     = ModuleName
-	RouterKey    = StoreKey
-	QuerierRoute = RouterKey
+	RouterKey    = ModuleName
+	QuerierRoute = ModuleName
 )
 
 var DidKey = []byte{0x01}

--- a/x/fees/internal/types/keys.go
+++ b/x/fees/internal/types/keys.go
@@ -4,6 +4,6 @@ const (
 	ModuleName        = "fees"
 	DefaultParamspace = ModuleName
 	StoreKey          = ModuleName
-	RouterKey         = StoreKey
-	QuerierRoute      = RouterKey
+	RouterKey         = ModuleName
+	QuerierRoute      = ModuleName
 )

--- a/x/oracles/internal/types/keys.go
+++ b/x/oracles/internal/types/keys.go
@@ -5,8 +5,8 @@ import "github.com/ixofoundation/ixo-cosmos/x/ixo"
 const (
 	ModuleName   = "oracles"
 	StoreKey     = ModuleName
-	RouterKey    = StoreKey
-	QuerierRoute = RouterKey
+	RouterKey    = ModuleName
+	QuerierRoute = ModuleName
 )
 
 var (

--- a/x/project/internal/types/keys.go
+++ b/x/project/internal/types/keys.go
@@ -8,8 +8,8 @@ const (
 	ModuleName        = "project"
 	DefaultParamspace = ModuleName
 	StoreKey          = ModuleName
-	RouterKey         = StoreKey
-	QuerierRoute      = RouterKey
+	RouterKey         = ModuleName
+	QuerierRoute      = ModuleName
 )
 
 var (

--- a/x/project/internal/types/msgs.go
+++ b/x/project/internal/types/msgs.go
@@ -19,7 +19,7 @@ type MsgCreateProject struct {
 
 var _ sdk.Msg = MsgCreateProject{}
 
-func (msg MsgCreateProject) Type() string  { return ModuleName }
+func (msg MsgCreateProject) Type() string  { return "create-project" }
 func (msg MsgCreateProject) Route() string { return RouterKey }
 func (msg MsgCreateProject) ValidateBasic() sdk.Error {
 	valid, err := CheckNotEmpty(msg.PubKey, "PubKey")
@@ -88,7 +88,7 @@ type MsgUpdateProjectStatus struct {
 	Data       UpdateProjectStatusDoc `json:"data" yaml:"data"`
 }
 
-func (msg MsgUpdateProjectStatus) Type() string             { return ModuleName }
+func (msg MsgUpdateProjectStatus) Type() string             { return "update-project-status" }
 func (msg MsgUpdateProjectStatus) Route() string            { return RouterKey }
 func (msg MsgUpdateProjectStatus) ValidateBasic() sdk.Error { return nil }
 func (msg MsgUpdateProjectStatus) GetSignBytes() []byte {
@@ -120,7 +120,7 @@ type MsgCreateAgent struct {
 
 func (msg MsgCreateAgent) IsNewDid() bool     { return false }
 func (msg MsgCreateAgent) IsWithdrawal() bool { return false }
-func (msg MsgCreateAgent) Type() string       { return ModuleName }
+func (msg MsgCreateAgent) Type() string       { return "create-agent" }
 func (msg MsgCreateAgent) Route() string      { return RouterKey }
 func (msg MsgCreateAgent) ValidateBasic() sdk.Error {
 	return nil
@@ -156,7 +156,7 @@ type MsgUpdateAgent struct {
 
 func (msg MsgUpdateAgent) IsNewDid() bool     { return false }
 func (msg MsgUpdateAgent) IsWithdrawal() bool { return false }
-func (msg MsgUpdateAgent) Type() string       { return ModuleName }
+func (msg MsgUpdateAgent) Type() string       { return "update-agent" }
 func (msg MsgUpdateAgent) Route() string      { return RouterKey }
 func (msg MsgUpdateAgent) ValidateBasic() sdk.Error {
 	return nil
@@ -193,7 +193,7 @@ type MsgCreateClaim struct {
 
 func (msg MsgCreateClaim) IsNewDid() bool     { return false }
 func (msg MsgCreateClaim) IsWithdrawal() bool { return false }
-func (msg MsgCreateClaim) Type() string       { return ModuleName }
+func (msg MsgCreateClaim) Type() string       { return "create-claim" }
 func (msg MsgCreateClaim) Route() string      { return RouterKey }
 func (msg MsgCreateClaim) ValidateBasic() sdk.Error {
 	return nil
@@ -230,7 +230,7 @@ type MsgCreateEvaluation struct {
 
 func (msg MsgCreateEvaluation) IsNewDid() bool     { return false }
 func (msg MsgCreateEvaluation) IsWithdrawal() bool { return false }
-func (msg MsgCreateEvaluation) Type() string       { return ModuleName }
+func (msg MsgCreateEvaluation) Type() string       { return "create-evaluation" }
 func (msg MsgCreateEvaluation) Route() string      { return RouterKey }
 func (msg MsgCreateEvaluation) ValidateBasic() sdk.Error {
 	return nil
@@ -265,7 +265,7 @@ type MsgWithdrawFunds struct {
 
 func (msg MsgWithdrawFunds) IsNewDid() bool     { return false }
 func (msg MsgWithdrawFunds) IsWithdrawal() bool { return true }
-func (msg MsgWithdrawFunds) Type() string       { return ModuleName }
+func (msg MsgWithdrawFunds) Type() string       { return "withdraw-funds" }
 func (msg MsgWithdrawFunds) Route() string      { return RouterKey }
 func (msg MsgWithdrawFunds) ValidateBasic() sdk.Error {
 	return nil

--- a/x/treasury/alias.go
+++ b/x/treasury/alias.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	ModuleName = types.ModuleName
-	RouterKey  = types.RouterKey
-	StoreKey   = types.StoreKey
+	ModuleName   = types.ModuleName
+	QuerierRoute = types.QuerierRoute
+	RouterKey    = types.RouterKey
+	StoreKey     = types.StoreKey
 )
 
 type (

--- a/x/treasury/internal/types/keys.go
+++ b/x/treasury/internal/types/keys.go
@@ -1,7 +1,8 @@
 package types
 
 const (
-	ModuleName = "treasury"
-	StoreKey   = ModuleName
-	RouterKey  = StoreKey
+	ModuleName   = "treasury"
+	StoreKey     = ModuleName
+	RouterKey    = ModuleName
+	QuerierRoute = ModuleName
 )

--- a/x/treasury/internal/types/msgs.go
+++ b/x/treasury/internal/types/msgs.go
@@ -24,7 +24,7 @@ type MsgSend struct {
 
 var _ TreasuryMessage = MsgSend{}
 
-func (msg MsgSend) Type() string  { return ModuleName }
+func (msg MsgSend) Type() string  { return "send" }
 func (msg MsgSend) Route() string { return RouterKey }
 func (msg MsgSend) ValidateBasic() sdk.Error {
 	valid, err := CheckNotEmpty(msg.PubKey, "PubKey")
@@ -79,7 +79,7 @@ type MsgOracleTransfer struct {
 
 var _ TreasuryMessage = MsgOracleTransfer{}
 
-func (msg MsgOracleTransfer) Type() string  { return ModuleName }
+func (msg MsgOracleTransfer) Type() string  { return "oracle-transfer" }
 func (msg MsgOracleTransfer) Route() string { return RouterKey }
 func (msg MsgOracleTransfer) ValidateBasic() sdk.Error {
 	valid, err := CheckNotEmpty(msg.PubKey, "PubKey")
@@ -137,7 +137,7 @@ type MsgOracleMint struct {
 
 var _ TreasuryMessage = MsgOracleMint{}
 
-func (msg MsgOracleMint) Type() string  { return ModuleName }
+func (msg MsgOracleMint) Type() string  { return "oracle-mint" }
 func (msg MsgOracleMint) Route() string { return RouterKey }
 func (msg MsgOracleMint) ValidateBasic() sdk.Error {
 	valid, err := CheckNotEmpty(msg.PubKey, "PubKey")
@@ -191,7 +191,7 @@ type MsgOracleBurn struct {
 
 var _ TreasuryMessage = MsgOracleBurn{}
 
-func (msg MsgOracleBurn) Type() string  { return ModuleName }
+func (msg MsgOracleBurn) Type() string  { return "oracle-burn" }
 func (msg MsgOracleBurn) Route() string { return RouterKey }
 func (msg MsgOracleBurn) ValidateBasic() sdk.Error {
 	valid, err := CheckNotEmpty(msg.PubKey, "PubKey")

--- a/x/treasury/module.go
+++ b/x/treasury/module.go
@@ -100,8 +100,7 @@ func (am AppModule) NewHandler() sdk.Handler {
 }
 
 func (AppModule) QuerierRoute() string {
-	// return QuerierRoute
-	return ""
+	return QuerierRoute
 }
 
 func (am AppModule) NewQuerierHandler() sdk.Querier {


### PR DESCRIPTION
In preparation for #77, the message types were improved to use a message-specific string. For example, the type for `MsgCreateProject` is now `create-project` rather than the module name `project`.

This meant however that the custom ixo AnteHandler in `app.go` broke, since it uses the `Type()` of a message to reroute messages. This was changed to use the message `Route()` instead, which is much more suitable given that the route is module-specific, so we're back to the AnteHandler working.