### PR TITLE
Addresses from ED25519 PubKeys

### DIFF
--- a/client/tx/txRoutes.go
+++ b/client/tx/txRoutes.go
@@ -12,7 +12,7 @@ import (
 	genutilrest "github.com/cosmos/cosmos-sdk/x/genutil/client/rest"
 	"github.com/gorilla/mux"
 	utils2 "github.com/ixofoundation/ixo-blockchain/client/utils"
-	"github.com/ixofoundation/ixo-blockchain/x/did"
+	"github.com/ixofoundation/ixo-blockchain/x/did/exported"
 	"github.com/ixofoundation/ixo-blockchain/x/ixo"
 	"github.com/ixofoundation/ixo-blockchain/x/project"
 	"io/ioutil"
@@ -159,7 +159,8 @@ func BroadcastTxRequest(cliCtx context.CLIContext) http.HandlerFunc {
 }
 
 type SignDataReq struct {
-	Msg string `json:"msg" yaml:"msg"`
+	Msg    string `json:"msg" yaml:"msg"`
+	PubKey string `json:"pub_key" yaml:"pub_key"`
 }
 
 type SignDataResponse struct {
@@ -212,7 +213,7 @@ func SignDataRequest(cliCtx context.CLIContext) http.HandlerFunc {
 				project.MsgCreateProjectFee)
 		default:
 			// Deduce and set signer address
-			signerAddress := did.DidToAddr(ixoMsg.GetSignerDid())
+			signerAddress := exported.VerifyKeyToAddr(req.PubKey)
 			cliCtx = cliCtx.WithFromAddress(signerAddress)
 
 			txBldr, err := utils.PrepareTxBuilder(auth.NewTxBuilderFromCLI(), cliCtx)

--- a/scripts/add_dummy_testnet_data.sh
+++ b/scripts/add_dummy_testnet_data.sh
@@ -198,12 +198,11 @@ echo "Updating project 2 to PENDING..."
 ixocli tx project update-project-status "$SENDER_DID" PENDING "$PROJECT2_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
 # Fund project (using treasury 'send' and 'oracle-transfer')
-echo "Funding project 2 (using treasury 'send' from Miguel)..."
-ixocli tx treasury send "$PROJECT2_DID/$PROJECT2_DID" 5000000000uixo "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Funding project 2 (using treasury 'oracle-transfer' from Miguel using Francesco oracle)..."
-ixocli tx treasury oracle-transfer "$MIGUEL_DID" "$PROJECT2_DID/$PROJECT2_DID" 5000000000uixo "$FRANCESCO_DID_FULL" "dummy proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-# The address behind "$PROJECT2_DID/$PROJECT2_DID" can also be obtained from (ixocli q project get-project-accounts $PROJECT2_DID)
-# Note that we're actually sending just 100uixo, since ixoDecimals is 1e8 and we're sending 100e8uixo
+PROJECT_2_ADDR=$(ixocli q project get-project-accounts $PROJECT2_DID | grep $PROJECT2_DID | cut -d \" -f 4)
+echo "Funding project 2 [$PROJECT_2_ADDR] (using treasury 'send' from Miguel)..."
+ixocli tx treasury send "$PROJECT_2_ADDR" 5000000000uixo "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Funding project 2 [$PROJECT_2_ADDR] (using treasury 'oracle-transfer' from Miguel using Francesco oracle)..."
+ixocli tx treasury oracle-transfer "$MIGUEL_DID" "$PROJECT_2_ADDR" 5000000000uixo "$FRANCESCO_DID_FULL" "dummy proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Updating project 2 to FUNDED..."
 SENDER_DID="$SHAUN_DID"
 ixocli tx project update-project-status "$SENDER_DID" FUNDED "$PROJECT2_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y

--- a/scripts/demo_bonds.sh
+++ b/scripts/demo_bonds.sh
@@ -26,8 +26,8 @@ FEE=$(yes $PASSWORD | ixocli keys show fee -a)
 BOND_DID="did:ixo:U7GK8p8rVhJMKhBVRCJJ8c"
 #BOND_DID_FULL="{\"did\":\"did:ixo:U7GK8p8rVhJMKhBVRCJJ8c\",\"verifyKey\":\"FmwNAfvV2xEqHwszrVJVBR3JgQ8AFCQEVzo1p6x4L8VW\",\"encryptionPublicKey\":\"domKpTpjrHQtKUnaFLjCuDLe2oHeS4b1sKt7yU9cq7m\",\"secret\":{\"seed\":\"933e454dbcfc1437f3afc10a0cd512cf0339787b6595819849f53707c268b053\",\"signKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\",\"encryptionPrivateKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\"}}"
 
-MIGUEL_ADDR="ixo1x2x0thq6x2rx7txl0ujpyg9rr0c8mc8ad904xw"
-FRANCESCO_ADDR="ixo1nnxvyr6hs0sglppqzw4v5s9r5dwh89423xu5zp"
+MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"
+FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y"
 MIGUEL_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"
 MIGUEL_DID_FULL="{\"did\":\"did:ixo:4XJLBfGtWSGKSz4BeRxdun\",\"verifyKey\":\"2vMHhssdhrBCRFiq9vj7TxGYDybW4yYdrYh9JG56RaAt\",\"encryptionPublicKey\":\"6GBp8qYgjE3ducksUa9Ar26ganhDFcmYfbZE9ezFx5xS\",\"secret\":{\"seed\":\"38734eeb53b5d69177da1fa9a093f10d218b3e0f81087226be6ce0cdce478180\",\"signKey\":\"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh\",\"encryptionPrivateKey\":\"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh\"}}"
 FRANCESCO_DID_FULL="{\"did\":\"did:ixo:UKzkhVSHc3qEFva5EY2XHt\",\"verifyKey\":\"Ftsqjc2pEvGLqBtgvVx69VXLe1dj2mFzoi4kqQNGo3Ej\",\"encryptionPublicKey\":\"8YScf3mY4eeHoxDT9MRxiuGX5Fw7edWFnwHpgWYSn1si\",\"secret\":{\"seed\":\"94f3c48a9b19b4881e582ba80f5767cd3f3c5d7b7103cb9a50fa018f108d89de\",\"signKey\":\"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM\",\"encryptionPrivateKey\":\"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM\"}}"

--- a/scripts/demo_bonds_swapper.sh
+++ b/scripts/demo_bonds_swapper.sh
@@ -32,8 +32,8 @@ FEE=$(yes $PASSWORD | ixocli keys show fee -a)
 BOND_DID="did:ixo:U7GK8p8rVhJMKhBVRCJJ8c"
 #BOND_DID_FULL="{\"did\":\"did:ixo:U7GK8p8rVhJMKhBVRCJJ8c\",\"verifyKey\":\"FmwNAfvV2xEqHwszrVJVBR3JgQ8AFCQEVzo1p6x4L8VW\",\"encryptionPublicKey\":\"domKpTpjrHQtKUnaFLjCuDLe2oHeS4b1sKt7yU9cq7m\",\"secret\":{\"seed\":\"933e454dbcfc1437f3afc10a0cd512cf0339787b6595819849f53707c268b053\",\"signKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\",\"encryptionPrivateKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\"}}"
 
-MIGUEL_ADDR="ixo1x2x0thq6x2rx7txl0ujpyg9rr0c8mc8ad904xw"
-FRANCESCO_ADDR="ixo1nnxvyr6hs0sglppqzw4v5s9r5dwh89423xu5zp"
+MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"
+FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y"
 MIGUEL_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"
 MIGUEL_DID_FULL="{\"did\":\"did:ixo:4XJLBfGtWSGKSz4BeRxdun\",\"verifyKey\":\"2vMHhssdhrBCRFiq9vj7TxGYDybW4yYdrYh9JG56RaAt\",\"encryptionPublicKey\":\"6GBp8qYgjE3ducksUa9Ar26ganhDFcmYfbZE9ezFx5xS\",\"secret\":{\"seed\":\"38734eeb53b5d69177da1fa9a093f10d218b3e0f81087226be6ce0cdce478180\",\"signKey\":\"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh\",\"encryptionPrivateKey\":\"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh\"}}"
 FRANCESCO_DID_FULL="{\"did\":\"did:ixo:UKzkhVSHc3qEFva5EY2XHt\",\"verifyKey\":\"Ftsqjc2pEvGLqBtgvVx69VXLe1dj2mFzoi4kqQNGo3Ej\",\"encryptionPublicKey\":\"8YScf3mY4eeHoxDT9MRxiuGX5Fw7edWFnwHpgWYSn1si\",\"secret\":{\"seed\":\"94f3c48a9b19b4881e582ba80f5767cd3f3c5d7b7103cb9a50fa018f108d89de\",\"signKey\":\"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM\",\"encryptionPrivateKey\":\"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM\"}}"

--- a/scripts/demo_gas_estimation.sh
+++ b/scripts/demo_gas_estimation.sh
@@ -39,8 +39,8 @@ FEE=$(yes $PASSWORD | ixocli keys show fee -a)
 BOND_DID="did:ixo:U7GK8p8rVhJMKhBVRCJJ8c"
 #BOND_DID_FULL="{\"did\":\"did:ixo:U7GK8p8rVhJMKhBVRCJJ8c\",\"verifyKey\":\"FmwNAfvV2xEqHwszrVJVBR3JgQ8AFCQEVzo1p6x4L8VW\",\"encryptionPublicKey\":\"domKpTpjrHQtKUnaFLjCuDLe2oHeS4b1sKt7yU9cq7m\",\"secret\":{\"seed\":\"933e454dbcfc1437f3afc10a0cd512cf0339787b6595819849f53707c268b053\",\"signKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\",\"encryptionPrivateKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\"}}"
 
-MIGUEL_ADDR="ixo1x2x0thq6x2rx7txl0ujpyg9rr0c8mc8ad904xw"
-FRANCESCO_ADDR="ixo1nnxvyr6hs0sglppqzw4v5s9r5dwh89423xu5zp"
+MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"
+FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y"
 MIGUEL_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"
 MIGUEL_DID_FULL="{\"did\":\"did:ixo:4XJLBfGtWSGKSz4BeRxdun\",\"verifyKey\":\"2vMHhssdhrBCRFiq9vj7TxGYDybW4yYdrYh9JG56RaAt\",\"encryptionPublicKey\":\"6GBp8qYgjE3ducksUa9Ar26ganhDFcmYfbZE9ezFx5xS\",\"secret\":{\"seed\":\"38734eeb53b5d69177da1fa9a093f10d218b3e0f81087226be6ce0cdce478180\",\"signKey\":\"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh\",\"encryptionPrivateKey\":\"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh\"}}"
 FRANCESCO_DID_FULL="{\"did\":\"did:ixo:UKzkhVSHc3qEFva5EY2XHt\",\"verifyKey\":\"Ftsqjc2pEvGLqBtgvVx69VXLe1dj2mFzoi4kqQNGo3Ej\",\"encryptionPublicKey\":\"8YScf3mY4eeHoxDT9MRxiuGX5Fw7edWFnwHpgWYSn1si\",\"secret\":{\"seed\":\"94f3c48a9b19b4881e582ba80f5767cd3f3c5d7b7103cb9a50fa018f108d89de\",\"signKey\":\"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM\",\"encryptionPrivateKey\":\"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM\"}}"

--- a/scripts/demo_project.sh
+++ b/scripts/demo_project.sh
@@ -20,7 +20,6 @@ if [[ ($RET == ERROR*) || ($RET == *'"latest_block_height": "0"'*) ]]; then
 fi
 
 GAS_PRICES="0.025uixo"
-PROJECT_FEE_FUND="45000uixo" # 0.025 * 200000 * 9txs
 
 PROJECT_DID="did:ixo:U7GK8p8rVhJMKhBVRCJJ8c"
 PROJECT_DID_FULL="{\"did\":\"did:ixo:U7GK8p8rVhJMKhBVRCJJ8c\",\"verifyKey\":\"FmwNAfvV2xEqHwszrVJVBR3JgQ8AFCQEVzo1p6x4L8VW\",\"encryptionPublicKey\":\"domKpTpjrHQtKUnaFLjCuDLe2oHeS4b1sKt7yU9cq7m\",\"secret\":{\"seed\":\"933e454dbcfc1437f3afc10a0cd512cf0339787b6595819849f53707c268b053\",\"signKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\",\"encryptionPrivateKey\":\"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC\"}}"
@@ -50,8 +49,13 @@ echo "Updating project to PENDING..."
 ixocli tx project update-project-status "$SENDER_DID" PENDING "$PROJECT_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
 # Fund project and progress status to FUNDED
-echo "Funding project (using treasury 'oracle-transfer' from Miguel using Francesco oracle)..."
-ixocli tx treasury oracle-transfer "$MIGUEL_DID" "$PROJECT_DID/$PROJECT_DID" 10000000000uixo "$FRANCESCO_DID_FULL" "dummy proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+PROJECT_ADDR=$(ixocli q project get-project-accounts $PROJECT_DID | grep "$PROJECT_DID" | cut -d \" -f 4)
+# TODO [[below two lines to be uncommented once treasury module supports sending to addresses]]
+# echo "Funding project at [$PROJECT_ADDR] (using treasury 'oracle-transfer' from Miguel using Francesco oracle)..."
+# ixocli tx treasury oracle-transfer "$MIGUEL_DID" "$PROJECT_ADDR" 10000000000uixo "$FRANCESCO_DID_FULL" "dummy proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+# TODO [[below two lines to be removed once treasury module supports sending to addresses]]
+echo "Funcing project [$PROJECT_ADDR] using send from miguel..."
+ixocli tx send miguel "$PROJECT_ADDR" 10000000000uixo --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Updating project to FUNDED..."
 SENDER_DID="$SHAUN_DID"
 ixocli tx project update-project-status "$SENDER_DID" FUNDED "$PROJECT_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y

--- a/scripts/demo_project.sh
+++ b/scripts/demo_project.sh
@@ -50,12 +50,8 @@ ixocli tx project update-project-status "$SENDER_DID" PENDING "$PROJECT_DID_FULL
 
 # Fund project and progress status to FUNDED
 PROJECT_ADDR=$(ixocli q project get-project-accounts $PROJECT_DID | grep "$PROJECT_DID" | cut -d \" -f 4)
-# TODO [[below two lines to be uncommented once treasury module supports sending to addresses]]
-# echo "Funding project at [$PROJECT_ADDR] (using treasury 'oracle-transfer' from Miguel using Francesco oracle)..."
-# ixocli tx treasury oracle-transfer "$MIGUEL_DID" "$PROJECT_ADDR" 10000000000uixo "$FRANCESCO_DID_FULL" "dummy proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-# TODO [[below two lines to be removed once treasury module supports sending to addresses]]
-echo "Funcing project [$PROJECT_ADDR] using send from miguel..."
-ixocli tx send miguel "$PROJECT_ADDR" 10000000000uixo --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Funding project at [$PROJECT_ADDR] (using treasury 'oracle-transfer' from Miguel using Francesco oracle)..."
+ixocli tx treasury oracle-transfer "$MIGUEL_DID" "$PROJECT_ADDR" 10000000000uixo "$FRANCESCO_DID_FULL" "dummy proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Updating project to FUNDED..."
 SENDER_DID="$SHAUN_DID"
 ixocli tx project update-project-status "$SENDER_DID" FUNDED "$PROJECT_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y

--- a/scripts/run_with_all_data.sh
+++ b/scripts/run_with_all_data.sh
@@ -27,10 +27,10 @@ yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 1000000
 yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 100000000uixos,100000000000uixo,1000000res,1000000rez
 yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 100000000uixos,100000000000uixo,1000000res,1000000rez
 
-# Add DID-based genesis accounts
-MIGUEL_ADDR="ixo1x2x0thq6x2rx7txl0ujpyg9rr0c8mc8ad904xw"    # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun
-FRANCESCO_ADDR="ixo1nnxvyr6hs0sglppqzw4v5s9r5dwh89423xu5zp" # address from did:ixo:UKzkhVSHc3qEFva5EY2XHt
-SHAUN_ADDR="ixo1vnsjples23f6ggtsvu5s24vv86ue0hl2hvnnsd"     # address from did:ixo:U4tSpzzv91HHqWW1YmFkHJ
+# Add pubkey-based genesis accounts
+MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"    # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun's pubkey
+FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y" # address from did:ixo:UKzkhVSHc3qEFva5EY2XHt's pubkey
+SHAUN_ADDR="ixo1d5u5ta7np7vefxa7ttpuy5aurg7q5regm0t2un"     # address from did:ixo:U4tSpzzv91HHqWW1YmFkHJ's pubkey
 yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 100000000uixos,100000000000uixo,1000000res,1000000rez
 yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 100000000uixos,100000000000uixo,1000000res,1000000rez
 yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 100000000uixos,100000000000uixo,1000000res,1000000rez
@@ -71,9 +71,9 @@ ixod collect-gentxs
 ixod validate-genesis
 
 # Uncomment the below to broadcast node RPC endpoint
-#FROM="laddr = \"tcp:\/\/127.0.0.1:26657\""
-#TO="laddr = \"tcp:\/\/0.0.0.0:26657\""
-#sed -i "s/$FROM/$TO/" "$HOME"/.ixod/config/config.toml
+FROM="laddr = \"tcp:\/\/127.0.0.1:26657\""
+TO="laddr = \"tcp:\/\/0.0.0.0:26657\""
+sed -i "s/$FROM/$TO/" "$HOME"/.ixod/config/config.toml
 
 ixod start --pruning "syncable" &
 ixocli rest-server --chain-id pandora-1 --trust-node && fg

--- a/scripts/run_with_all_data.sh
+++ b/scripts/run_with_all_data.sh
@@ -71,9 +71,9 @@ ixod collect-gentxs
 ixod validate-genesis
 
 # Uncomment the below to broadcast node RPC endpoint
-FROM="laddr = \"tcp:\/\/127.0.0.1:26657\""
-TO="laddr = \"tcp:\/\/0.0.0.0:26657\""
-sed -i "s/$FROM/$TO/" "$HOME"/.ixod/config/config.toml
+#FROM="laddr = \"tcp:\/\/127.0.0.1:26657\""
+#TO="laddr = \"tcp:\/\/0.0.0.0:26657\""
+#sed -i "s/$FROM/$TO/" "$HOME"/.ixod/config/config.toml
 
 ixod start --pruning "syncable" &
 ixocli rest-server --chain-id pandora-1 --trust-node && fg

--- a/scripts/run_with_some_data.sh
+++ b/scripts/run_with_some_data.sh
@@ -10,8 +10,8 @@ yes $PASSWORD | ixocli keys add miguel
 # Note: important to add 'miguel' as a genesis-account since this is the chain's validator
 yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 100000000uixos,100000000000uixo,1000000res,1000000rez
 
-# Add DID-based genesis account
-MIGUEL_ADDR="ixo1x2x0thq6x2rx7txl0ujpyg9rr0c8mc8ad904xw" # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun
+# Add pubkey-based genesis accounts
+MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"    # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun's pubkey
 yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 100000000uixos,100000000000uixo,1000000res,1000000rez
 
 # Add genesis oracle

--- a/scripts/samples/payment_template.json
+++ b/scripts/samples/payment_template.json
@@ -11,7 +11,7 @@
   "discounts": [],
   "wallet_distribution": [
     {
-      "address": "ixo1x2x0thq6x2rx7txl0ujpyg9rr0c8mc8ad904xw",
+      "address": "ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx",
       "percentage": "100"
     }
   ]

--- a/x/bonds/client/cli/tx.go
+++ b/x/bonds/client/cli/tx.go
@@ -123,7 +123,7 @@ func GetCmdCreateBond(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(creatorDid.Did))
+				WithFromAddress(creatorDid.Address())
 
 			msg := types.NewMsgCreateBond(_token, _name, _description,
 				creatorDid.Did, _functionType, functionParams, reserveTokens,
@@ -180,7 +180,7 @@ func GetCmdEditBond(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(editorDid.Did))
+				WithFromAddress(editorDid.Address())
 
 			msg := types.NewMsgEditBond(
 				_token, _name, _description, _orderQuantityLimits, _sanityRate,
@@ -226,7 +226,7 @@ func GetCmdBuy(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(buyerDid.Did))
+				WithFromAddress(buyerDid.Address())
 
 			msg := types.NewMsgBuy(
 				buyerDid.Did, bondCoinWithAmount, maxPrices, args[2])
@@ -256,7 +256,7 @@ func GetCmdSell(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(sellerDid.Did))
+				WithFromAddress(sellerDid.Address())
 
 			msg := types.NewMsgSell(sellerDid.Did, bondCoinWithAmount, args[1])
 
@@ -288,7 +288,7 @@ func GetCmdSwap(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(swapperDid.Did))
+				WithFromAddress(swapperDid.Address())
 
 			msg := types.NewMsgSwap(swapperDid.Did, from, args[2], args[3])
 

--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -5,7 +5,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ixofoundation/ixo-blockchain/x/bonds/internal/keeper"
 	"github.com/ixofoundation/ixo-blockchain/x/bonds/internal/types"
-	"github.com/ixofoundation/ixo-blockchain/x/did"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"strings"
 )
@@ -207,7 +206,7 @@ func handleMsgEditBond(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgEditB
 }
 
 func handleMsgBuy(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgBuy) sdk.Result {
-	buyerAddr := did.DidToAddr(msg.BuyerDid)
+	buyerAddr := keeper.DidKeeper.MustGetDidDoc(ctx, msg.BuyerDid).Address()
 
 	bond, found := keeper.GetBond(ctx, msg.BondDid)
 	if !found {
@@ -276,7 +275,7 @@ func handleMsgBuy(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgBuy) sdk.R
 }
 
 func performFirstSwapperFunctionBuy(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgBuy) sdk.Result {
-	buyerAddr := did.DidToAddr(msg.BuyerDid)
+	buyerAddr := keeper.DidKeeper.MustGetDidDoc(ctx, msg.BuyerDid).Address()
 
 	// TODO: investigate effect that a high amount has on future buyers' ability to buy.
 
@@ -336,7 +335,7 @@ func performFirstSwapperFunctionBuy(ctx sdk.Context, keeper keeper.Keeper, msg t
 }
 
 func handleMsgSell(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgSell) sdk.Result {
-	sellerAddr := did.DidToAddr(msg.SellerDid)
+	sellerAddr := keeper.DidKeeper.MustGetDidDoc(ctx, msg.SellerDid).Address()
 
 	bond, found := keeper.GetBond(ctx, msg.BondDid)
 	if !found {
@@ -403,7 +402,7 @@ func handleMsgSell(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgSell) sdk
 }
 
 func handleMsgSwap(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgSwap) sdk.Result {
-	swapperAddr := did.DidToAddr(msg.SwapperDid)
+	swapperAddr := keeper.DidKeeper.MustGetDidDoc(ctx, msg.SwapperDid).Address()
 
 	bond, found := keeper.GetBond(ctx, msg.BondDid)
 	if !found {

--- a/x/bonds/internal/keeper/keeper.go
+++ b/x/bonds/internal/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 	"github.com/ixofoundation/ixo-blockchain/x/bonds/internal/types"
+	"github.com/ixofoundation/ixo-blockchain/x/did"
 	"github.com/tendermint/tendermint/libs/log"
 )
 
@@ -17,6 +18,7 @@ type Keeper struct {
 	SupplyKeeper  supply.Keeper
 	accountKeeper auth.AccountKeeper
 	StakingKeeper staking.Keeper
+	DidKeeper     did.Keeper
 
 	storeKey sdk.StoreKey
 
@@ -25,7 +27,7 @@ type Keeper struct {
 
 func NewKeeper(bankKeeper bank.Keeper, supplyKeeper supply.Keeper,
 	accountKeeper auth.AccountKeeper, stakingKeeper staking.Keeper,
-	storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
+	didKeeper did.Keeper, storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
 
 	// ensure batches module account is set
 	if addr := supplyKeeper.GetModuleAddress(types.BatchesIntermediaryAccount); addr == nil {
@@ -37,6 +39,7 @@ func NewKeeper(bankKeeper bank.Keeper, supplyKeeper supply.Keeper,
 		SupplyKeeper:  supplyKeeper,
 		accountKeeper: accountKeeper,
 		StakingKeeper: stakingKeeper,
+		DidKeeper:     didKeeper,
 		storeKey:      storeKey,
 		cdc:           cdc,
 	}

--- a/x/bonds/internal/keeper/querier.go
+++ b/x/bonds/internal/keeper/querier.go
@@ -56,7 +56,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 func zeroReserveTokensIfEmpty(reserveCoins sdk.Coins, bond types.Bond) sdk.Coins {
 	if reserveCoins.IsZero() {
 		zeroes, _ := bond.GetNewReserveDecCoins(sdk.OneDec()).TruncateDecimal()
-		for i, _ := range zeroes {
+		for i := range zeroes {
 			zeroes[i].Amount = sdk.ZeroInt()
 		}
 		reserveCoins = zeroes

--- a/x/bonds/internal/types/msgs.go
+++ b/x/bonds/internal/types/msgs.go
@@ -173,7 +173,7 @@ func (msg MsgCreateBond) GetSignBytes() []byte {
 
 func (msg MsgCreateBond) GetSignerDid() did.Did { return msg.CreatorDid }
 func (msg MsgCreateBond) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreateBond) Route() string { return RouterKey }
@@ -261,7 +261,7 @@ func (msg MsgEditBond) GetSignBytes() []byte {
 
 func (msg MsgEditBond) GetSignerDid() did.Did { return msg.EditorDid }
 func (msg MsgEditBond) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgEditBond) Route() string { return RouterKey }
@@ -325,7 +325,7 @@ func (msg MsgBuy) GetSignBytes() []byte {
 
 func (msg MsgBuy) GetSignerDid() did.Did { return msg.BuyerDid }
 func (msg MsgBuy) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgBuy) Route() string { return RouterKey }
@@ -381,7 +381,7 @@ func (msg MsgSell) GetSignBytes() []byte {
 
 func (msg MsgSell) GetSignerDid() did.Did { return msg.SellerDid }
 func (msg MsgSell) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgSell) Route() string { return RouterKey }
@@ -458,7 +458,7 @@ func (msg MsgSwap) GetSignBytes() []byte {
 
 func (msg MsgSwap) GetSignerDid() did.Did { return msg.SwapperDid }
 func (msg MsgSwap) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgSwap) Route() string { return RouterKey }

--- a/x/did/alias.go
+++ b/x/did/alias.go
@@ -22,6 +22,9 @@ type (
 	Did    = exported.Did
 	DidDoc = exported.DidDoc
 	IxoDid = exported.IxoDid
+
+	MsgAddDid        = types.MsgAddDid
+	MsgAddCredential = types.MsgAddCredential
 )
 
 var (
@@ -40,7 +43,6 @@ var (
 	ErrorInvalidDid = types.ErrorInvalidDid
 
 	IsValidDid      = types.IsValidDid
-	DidToAddr       = types.DidToAddr
-	StringToAddr    = types.StringToAddr
+	IsValidPubKey   = types.IsValidPubKey
 	UnmarshalIxoDid = types.UnmarshalIxoDid
 )

--- a/x/did/auth.go
+++ b/x/did/auth.go
@@ -3,29 +3,27 @@ package did
 import (
 	"github.com/btcsuite/btcutil/base58"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ixofoundation/ixo-blockchain/x/did/internal/types"
 	"github.com/ixofoundation/ixo-blockchain/x/ixo"
-	"github.com/tendermint/ed25519"
 	"github.com/tendermint/tendermint/crypto"
-	ed25519Keys "github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
 func GetPubKeyGetter(keeper Keeper) ixo.PubKeyGetter {
 	return func(ctx sdk.Context, msg ixo.IxoMsg) (pubKey crypto.PubKey, res sdk.Result) {
 
 		// Get signer PubKey
-		var pubKeyRaw [ed25519.PublicKeySize]byte
+		var pubKeyEd25519 ed25519.PubKeyEd25519
 		switch msg := msg.(type) {
-		case types.MsgAddDid:
-			copy(pubKeyRaw[:], base58.Decode(msg.DidDoc.PubKey))
+		case MsgAddDid:
+			copy(pubKeyEd25519[:], base58.Decode(msg.DidDoc.PubKey))
 		default:
 			// For the remaining messages, the did is the signer
 			didDoc, _ := keeper.GetDidDoc(ctx, msg.GetSignerDid())
 			if didDoc == nil {
 				return pubKey, sdk.ErrUnauthorized("Issuer did not found").Result()
 			}
-			copy(pubKeyRaw[:], base58.Decode(didDoc.GetPubKey()))
+			copy(pubKeyEd25519[:], base58.Decode(didDoc.GetPubKey()))
 		}
-		return ed25519Keys.PubKeyEd25519(pubKeyRaw), sdk.Result{}
+		return pubKeyEd25519, sdk.Result{}
 	}
 }

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -24,7 +24,7 @@ func GetCmdAddDidDoc(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(types.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgAddDid(ixoDid.Did, ixoDid.VerifyKey)
 			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, ixoDid)
@@ -51,7 +51,7 @@ func GetCmdAddCredential(cdc *codec.Codec) *cobra.Command {
 			credTypes := []string{"Credential", "ProofOfKYC"}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(types.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgAddCredential(didAddr, credTypes, ixoDid.Did, issued)
 			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, ixoDid)

--- a/x/did/client/rest/query.go
+++ b/x/did/client/rest/query.go
@@ -16,9 +16,28 @@ import (
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	// The .* is necessary so that a slash in the did gets included as part of the did
 	r.HandleFunc("/didToAddr/{did:.*}", queryAddressFromDidRequestHandler(cliCtx)).Methods("GET")
+	r.HandleFunc("/pubKeyToAddr/{pubKey}", queryAddressFromBase58EncodedPubkeyRequestHandler(cliCtx)).Methods("GET")
 	r.HandleFunc("/did/{did}", queryDidDocRequestHandler(cliCtx)).Methods("GET")
 	r.HandleFunc("/did", queryAllDidsRequestHandler(cliCtx)).Methods("GET")
 	r.HandleFunc("/allDidDocs", queryAllDidDocsRequestHandler(cliCtx)).Methods("GET")
+}
+
+func queryAddressFromBase58EncodedPubkeyRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		w.Header().Set("Content-Type", "application/json")
+		vars := mux.Vars(r)
+
+		if !types.IsValidPubKey(vars["pubKey"]) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("input is not a valid base-58 encoded pubKey"))
+			return
+		}
+
+		accAddress := exported.VerifyKeyToAddr(vars["pubKey"])
+
+		rest.PostProcessResponse(w, cliCtx.Codec, accAddress, true)
+	}
 }
 
 func queryAddressFromDidRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
@@ -26,16 +45,26 @@ func queryAddressFromDidRequestHandler(cliCtx context.CLIContext) http.HandlerFu
 
 		w.Header().Set("Content-Type", "application/json")
 		vars := mux.Vars(r)
-
-		if !types.IsValidDid(vars["did"]) {
+		didAddr := vars["did"]
+		key := exported.Did(didAddr)
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute,
+			keeper.QueryDidDoc, key), nil)
+		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte("input is not a valid did"))
+			_, _ = w.Write([]byte(err.Error()))
+			return
+		}
+		if len(res) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+			_, _ = w.Write([]byte("No data for respected did address."))
 			return
 		}
 
-		accAddress := types.DidToAddr(vars["did"])
+		var didDoc types.BaseDidDoc
+		cliCtx.Codec.MustUnmarshalJSON(res, &didDoc)
+		addressFromDid := didDoc.Address()
 
-		rest.PostProcessResponse(w, cliCtx.Codec, accAddress, true)
+		rest.PostProcessResponse(w, cliCtx.Codec, addressFromDid, true)
 	}
 }
 

--- a/x/did/internal/keeper/keeper.go
+++ b/x/did/internal/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ixofoundation/ixo-blockchain/x/did/exported"
@@ -24,13 +25,22 @@ func (k Keeper) GetDidDoc(ctx sdk.Context, did exported.Did) (exported.DidDoc, s
 	key := types.GetDidPrefixKey(did)
 	bz := store.Get(key)
 	if bz == nil {
-		return nil, types.ErrorInvalidDid(types.DefaultCodespace, "Invalid Did Address")
+		return nil, types.ErrorInvalidDid(
+			types.DefaultCodespace, fmt.Sprintf("Invalid Did Address %s", did))
 	}
 
 	var didDoc types.BaseDidDoc
 	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &didDoc)
 
 	return didDoc, nil
+}
+
+func (k Keeper) MustGetDidDoc(ctx sdk.Context, did exported.Did) exported.DidDoc {
+	didDoc, err := k.GetDidDoc(ctx, did)
+	if err != nil {
+		panic(err)
+	}
+	return didDoc
 }
 
 func (k Keeper) SetDidDoc(ctx sdk.Context, did exported.DidDoc) (err sdk.Error) {

--- a/x/did/internal/keeper/keeper_test.go
+++ b/x/did/internal/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/ixofoundation/ixo-blockchain/x/did/exported"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,7 +11,7 @@ import (
 
 func TestKeeper(t *testing.T) {
 	ctx, k, cdc := CreateTestInput()
-	cdc.RegisterInterface((*DidDoc)(nil), nil)
+	cdc.RegisterInterface((*exported.DidDoc)(nil), nil)
 	_, err := k.GetDidDoc(ctx, types.EmptyDid)
 	require.NotNil(t, err)
 

--- a/x/did/internal/keeper/querier_test.go
+++ b/x/did/internal/keeper/querier_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/ixofoundation/ixo-blockchain/x/did/exported"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,7 +12,7 @@ import (
 
 func TestQueryDidDocs(t *testing.T) {
 	ctx, k, cdc := CreateTestInput()
-	cdc.RegisterInterface((*DidDoc)(nil), nil)
+	cdc.RegisterInterface((*exported.DidDoc)(nil), nil)
 	err := k.SetDidDoc(ctx, &types.ValidDidDoc)
 	require.Nil(t, err)
 

--- a/x/did/internal/types/msgs.go
+++ b/x/did/internal/types/msgs.go
@@ -53,7 +53,7 @@ func (msg MsgAddDid) Route() string { return RouterKey }
 
 func (msg MsgAddDid) GetSignerDid() exported.Did { return msg.DidDoc.Did }
 func (msg MsgAddDid) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgAddDid) ValidateBasic() sdk.Error {
@@ -118,7 +118,7 @@ func (msg MsgAddCredential) Route() string { return RouterKey }
 
 func (msg MsgAddCredential) GetSignerDid() exported.Did { return msg.DidCredential.Issuer }
 func (msg MsgAddCredential) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgAddCredential) String() string {

--- a/x/did/internal/types/types.go
+++ b/x/did/internal/types/types.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ixofoundation/ixo-blockchain/x/did/exported"
-	"github.com/tendermint/tendermint/crypto"
 	"regexp"
 )
 
 var (
-	ValidDid   = regexp.MustCompile(`^did:(ixo:|sov:)([a-zA-Z0-9]){21,22}([/][a-zA-Z0-9:]+|)$`)
-	IsValidDid = ValidDid.MatchString
+	ValidDid      = regexp.MustCompile(`^did:(ixo:|sov:)([a-zA-Z0-9]){21,22}([/][a-zA-Z0-9:]+|)$`)
+	ValidPubKey   = regexp.MustCompile(`^[123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ]{44}$`)
+	IsValidDid    = ValidDid.MatchString
+	IsValidPubKey = ValidPubKey.MatchString
 	// https://sovrin-foundation.github.io/sovrin/spec/did-method-spec-template.html
 	// IsValidDid adapted from the above link but assumes no sub-namespaces
 	// TODO: ValidDid needs to be updated once we no longer want to be able
@@ -60,6 +61,10 @@ func (dd BaseDidDoc) SetPubKey(pubKey string) error {
 	return nil
 }
 
+func (dd BaseDidDoc) Address() sdk.AccAddress {
+	return exported.VerifyKeyToAddr(dd.GetPubKey())
+}
+
 func (dd *BaseDidDoc) AddCredential(cred exported.DidCredential) {
 	if dd.Credentials == nil {
 		dd.Credentials = make([]exported.DidCredential, 0)
@@ -83,16 +88,4 @@ func fromJsonString(jsonIxoDid string) (exported.IxoDid, error) {
 
 func UnmarshalIxoDid(jsonIxoDid string) (exported.IxoDid, error) {
 	return fromJsonString(jsonIxoDid)
-}
-
-func DidToAddr(did exported.Did) sdk.AccAddress {
-	// TODO: pubkey-to-addr instead of did-to-addr
-	//var pubKey ed25519Keys.PubKeyEd25519
-	//copy(pubKey[:], base58.Decode(pubKeyStr))
-	//return sdk.AccAddress(pubKey.Address())
-	return StringToAddr(did)
-}
-
-func StringToAddr(str string) sdk.AccAddress {
-	return sdk.AccAddress(crypto.AddressHash([]byte(str)))
 }

--- a/x/did/module.go
+++ b/x/did/module.go
@@ -76,7 +76,8 @@ func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 	}
 
 	didQueryCmd.AddCommand(client.GetCommands(
-		cli.GetCmdAddressFromDid(),
+		cli.GetCmdAddressFromBase58Pubkey(),
+		cli.GetCmdAddressFromDid(cdc),
 		cli.GetCmdDidDoc(cdc),
 		cli.GetCmdAllDids(cdc),
 		cli.GetCmdAllDidDocs(cdc),

--- a/x/ixo/internal/types/tx.go
+++ b/x/ixo/internal/types/tx.go
@@ -119,10 +119,6 @@ func (tx IxoTx) String() string {
 	return fmt.Sprintf("%v", string(output))
 }
 
-func (tx IxoTx) GetSigner() sdk.AccAddress {
-	return tx.GetMsgs()[0].GetSigners()[0]
-}
-
 func DefaultTxDecoder(cdc *codec.Codec) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, sdk.Error) {
 

--- a/x/payments/client/cli/tx.go
+++ b/x/payments/client/cli/tx.go
@@ -52,7 +52,7 @@ func GetCmdCreatePaymentTemplate(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreatePaymentTemplate(template, ixoDid.Did)
 
@@ -96,7 +96,7 @@ func GetCmdCreatePaymentContract(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreatePaymentContract(
 				templateIdStr, contractIdStr, payerAddr,
@@ -137,7 +137,7 @@ func GetCmdCreateSubscription(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreateSubscription(subIdStr,
 				contractIdStr, maxPeriods, period, ixoDid.Did)
@@ -169,7 +169,7 @@ func GetCmdSetPaymentContractAuthorisation(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgSetPaymentContractAuthorisation(
 				contractIdStr, authorised, ixoDid.Did)
@@ -207,7 +207,7 @@ func GetCmdGrantPaymentDiscount(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgGrantDiscount(
 				contractIdStr, discountId, recipientAddr, ixoDid.Did)
@@ -238,7 +238,7 @@ func GetCmdRevokePaymentDiscount(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgRevokeDiscount(
 				contractIdStr, holderAddr, ixoDid.Did)
@@ -263,7 +263,7 @@ func GetCmdEffectPayment(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgEffectPayment(contractIdStr, ixoDid.Did)
 

--- a/x/payments/handler.go
+++ b/x/payments/handler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
-	"github.com/ixofoundation/ixo-blockchain/x/did"
 	"github.com/ixofoundation/ixo-blockchain/x/payments/internal/keeper"
 	"github.com/ixofoundation/ixo-blockchain/x/payments/internal/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -79,8 +78,14 @@ func handleMsgSetPaymentContractAuthorisation(ctx sdk.Context, k Keeper, msg Msg
 		return err.Result()
 	}
 
+	// Get payer address
+	payerDidDoc, err := k.DidKeeper.GetDidDoc(ctx, msg.PayerDid)
+	if err != nil {
+		return err.Result()
+	}
+	payerAddr := payerDidDoc.Address()
+
 	// Confirm that signer is actually the payer in the payment contract
-	payerAddr := did.DidToAddr(msg.PayerDid)
 	if !payerAddr.Equals(contract.Payer) {
 		return sdk.ErrInvalidAddress("signer must be payment contract payer").Result()
 	}
@@ -153,8 +158,14 @@ func handleMsgCreatePaymentContract(ctx sdk.Context, k Keeper, bk bank.Keeper,
 		return sdk.ErrInternal("invalid payment template").Result()
 	}
 
+	// Get creator address
+	cretorDidDoc, err := k.DidKeeper.GetDidDoc(ctx, msg.CreatorDid)
+	if err != nil {
+		return err.Result()
+	}
+	creatorAddr := cretorDidDoc.Address()
+
 	// Create payment contract and validate
-	creatorAddr := did.DidToAddr(msg.CreatorDid)
 	contract := NewPaymentContract(msg.PaymentContractId, msg.PaymentTemplateId,
 		creatorAddr, msg.Payer, msg.CanDeauthorise, false, msg.DiscountId)
 	if err := contract.Validate(); err != nil {
@@ -188,8 +199,14 @@ func handleMsgCreateSubscription(ctx sdk.Context, k Keeper,
 		return err.Result()
 	}
 
+	// Get creator address
+	cretorDidDoc, err := k.DidKeeper.GetDidDoc(ctx, msg.CreatorDid)
+	if err != nil {
+		return err.Result()
+	}
+	creatorAddr := cretorDidDoc.Address()
+
 	// Confirm that signer is actually the creator of the payment contract
-	creatorAddr := did.DidToAddr(msg.CreatorDid)
 	if !creatorAddr.Equals(contract.Creator) {
 		return sdk.ErrInvalidAddress("signer must be payment contract creator").Result()
 	}
@@ -215,8 +232,14 @@ func handleMsgGrantDiscount(ctx sdk.Context, k Keeper, msg MsgGrantDiscount) sdk
 		return err.Result()
 	}
 
+	// Get creator address
+	creatorDidDoc, err := k.DidKeeper.GetDidDoc(ctx, msg.SenderDid)
+	if err != nil {
+		return err.Result()
+	}
+	creatorAddr := creatorDidDoc.Address()
+
 	// Confirm that signer is actually the creator of the payment contract
-	creatorAddr := did.DidToAddr(msg.SenderDid)
 	if !creatorAddr.Equals(contract.Creator) {
 		return sdk.ErrInvalidAddress("signer must be payment contract creator").Result()
 	}
@@ -247,8 +270,14 @@ func handleMsgRevokeDiscount(ctx sdk.Context, k Keeper, msg MsgRevokeDiscount) s
 		return err.Result()
 	}
 
+	// Get creator address
+	cretorDidDoc, err := k.DidKeeper.GetDidDoc(ctx, msg.SenderDid)
+	if err != nil {
+		return err.Result()
+	}
+	creatorAddr := cretorDidDoc.Address()
+
 	// Confirm that signer is actually the creator of the payment contract
-	creatorAddr := did.DidToAddr(msg.SenderDid)
 	if !creatorAddr.Equals(contract.Creator) {
 		return sdk.ErrInvalidAddress("signer must be payment contract creator").Result()
 	}
@@ -270,8 +299,14 @@ func handleMsgEffectPayment(ctx sdk.Context, k Keeper, bk bank.Keeper, msg MsgEf
 		return err.Result()
 	}
 
+	// Get creator address
+	cretorDidDoc, err := k.DidKeeper.GetDidDoc(ctx, msg.SenderDid)
+	if err != nil {
+		return err.Result()
+	}
+	creatorAddr := cretorDidDoc.Address()
+
 	// Confirm that signer is actually the creator of the payment contract
-	creatorAddr := did.DidToAddr(msg.SenderDid)
 	if !creatorAddr.Equals(contract.Creator) {
 		return sdk.ErrInvalidAddress("signer must be payment contract creator").Result()
 	}

--- a/x/payments/internal/keeper/keeper.go
+++ b/x/payments/internal/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/ixofoundation/ixo-blockchain/x/did"
 	"github.com/ixofoundation/ixo-blockchain/x/payments/internal/types"
 	"strings"
 )
@@ -14,16 +15,19 @@ type Keeper struct {
 	storeKey           sdk.StoreKey
 	paramSpace         params.Subspace
 	bankKeeper         bank.Keeper
+	DidKeeper          did.Keeper
 	reservedIdPrefixes []string
 }
 
-func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, paramSpace params.Subspace,
-	bankKeeper bank.Keeper, reservedIdPrefixes []string) Keeper {
+func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey,
+	paramSpace params.Subspace, bankKeeper bank.Keeper,
+	didKeeper did.Keeper, reservedIdPrefixes []string) Keeper {
 	return Keeper{
 		cdc:                cdc,
 		storeKey:           storeKey,
 		paramSpace:         paramSpace.WithKeyTable(types.ParamKeyTable()),
 		bankKeeper:         bankKeeper,
+		DidKeeper:          didKeeper,
 		reservedIdPrefixes: reservedIdPrefixes,
 	}
 }

--- a/x/payments/internal/keeper/test_common.go
+++ b/x/payments/internal/keeper/test_common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/ixofoundation/ixo-blockchain/x/did"
 	"github.com/ixofoundation/ixo-blockchain/x/payments/internal/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -101,11 +102,13 @@ func CreateTestInput() (sdk.Context, Keeper, *codec.Codec) {
 
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	actStoreKey := sdk.NewKVStoreKey(auth.StoreKey)
+	keyDid := sdk.NewKVStoreKey(did.StoreKey)
 
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)
 	ms.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, nil)
 	ms.MountStoreWithDB(actStoreKey, sdk.StoreTypeIAVL, nil)
+	ms.MountStoreWithDB(keyDid, sdk.StoreTypeIAVL, nil)
 
 	_ = ms.LoadLatestVersion()
 	ctx := sdk.NewContext(ms, abci.Header{}, true, log.NewNopLogger())
@@ -125,8 +128,8 @@ func CreateTestInput() (sdk.Context, Keeper, *codec.Codec) {
 
 	accountKeeper := auth.NewAccountKeeper(cdc, actStoreKey, pk1.Subspace(auth.DefaultParamspace), auth.ProtoBaseAccount)
 	bankKeeper := bank.NewBaseKeeper(accountKeeper, pk1.Subspace(bank.DefaultParamspace), bank.DefaultCodespace, nil)
-
-	keeper := NewKeeper(cdc, storeKey, paymentsSubspace, bankKeeper, nil)
+	didKeeper := did.NewKeeper(cdc, keyDid)
+	keeper := NewKeeper(cdc, storeKey, paymentsSubspace, bankKeeper, didKeeper, nil)
 
 	return ctx, keeper, cdc
 }

--- a/x/payments/internal/types/msgs.go
+++ b/x/payments/internal/types/msgs.go
@@ -57,7 +57,7 @@ func (msg MsgCreatePaymentTemplate) ValidateBasic() sdk.Error {
 
 func (msg MsgCreatePaymentTemplate) GetSignerDid() did.Did { return msg.CreatorDid }
 func (msg MsgCreatePaymentTemplate) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreatePaymentTemplate) String() string {
@@ -112,7 +112,7 @@ func (msg MsgCreatePaymentContract) ValidateBasic() sdk.Error {
 
 func (msg MsgCreatePaymentContract) GetSignerDid() did.Did { return msg.CreatorDid }
 func (msg MsgCreatePaymentContract) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreatePaymentContract) String() string {
@@ -167,7 +167,7 @@ func (msg MsgCreateSubscription) ValidateBasic() sdk.Error {
 
 func (msg MsgCreateSubscription) GetSignerDid() did.Did { return msg.CreatorDid }
 func (msg MsgCreateSubscription) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreateSubscription) String() string {
@@ -217,7 +217,7 @@ func (msg MsgSetPaymentContractAuthorisation) ValidateBasic() sdk.Error {
 
 func (msg MsgSetPaymentContractAuthorisation) GetSignerDid() did.Did { return msg.PayerDid }
 func (msg MsgSetPaymentContractAuthorisation) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgSetPaymentContractAuthorisation) String() string {
@@ -268,7 +268,7 @@ func (msg MsgGrantDiscount) ValidateBasic() sdk.Error {
 
 func (msg MsgGrantDiscount) GetSignerDid() did.Did { return msg.SenderDid }
 func (msg MsgGrantDiscount) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgGrantDiscount) String() string {
@@ -318,7 +318,7 @@ func (msg MsgRevokeDiscount) ValidateBasic() sdk.Error {
 
 func (msg MsgRevokeDiscount) GetSignerDid() did.Did { return msg.SenderDid }
 func (msg MsgRevokeDiscount) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgRevokeDiscount) String() string {
@@ -365,7 +365,7 @@ func (msg MsgEffectPayment) ValidateBasic() sdk.Error {
 
 func (msg MsgEffectPayment) GetSignerDid() did.Did { return msg.SenderDid }
 func (msg MsgEffectPayment) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgEffectPayment) String() string {

--- a/x/project/client/cli/tx.go
+++ b/x/project/client/cli/tx.go
@@ -33,7 +33,7 @@ func GetCmdCreateProject(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreateProject(senderDid, projectDoc, ixoDid)
 			stdSignMsg := msg.ToStdSignMsg(types.MsgCreateProjectFee)
@@ -79,7 +79,7 @@ func GetCmdUpdateProjectStatus(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgUpdateProjectStatus(senderDid, updateProjectStatusDoc, ixoDid)
 
@@ -114,7 +114,7 @@ func GetCmdCreateAgent(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreateAgent(txHash, senderDid, createAgentDoc, ixoDid)
 
@@ -151,7 +151,7 @@ func GetCmdUpdateAgent(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgUpdateAgent(txHash, senderDid, updateAgentDoc, ixoDid)
 
@@ -179,7 +179,7 @@ func GetCmdCreateClaim(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreateClaim(txHash, senderDid, createClaimDoc, ixoDid)
 
@@ -214,7 +214,7 @@ func GetCmdCreateEvaluation(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgCreateEvaluation(txHash, senderDid, createEvaluationDoc, ixoDid)
 
@@ -229,7 +229,7 @@ func GetCmdWithdrawFunds(cdc *codec.Codec) *cobra.Command {
 		Short: "Withdraw funds.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			senderDid, err := did.UnmarshalIxoDid(args[0])
+			ixoDid, err := did.UnmarshalIxoDid(args[0])
 			if err != nil {
 				return err
 			}
@@ -241,11 +241,11 @@ func GetCmdWithdrawFunds(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(senderDid.Did))
+				WithFromAddress(ixoDid.Address())
 
-			msg := types.NewMsgWithdrawFunds(senderDid.Did, data)
+			msg := types.NewMsgWithdrawFunds(ixoDid.Did, data)
 
-			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, senderDid)
+			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, ixoDid)
 		},
 	}
 }

--- a/x/project/handler.go
+++ b/x/project/handler.go
@@ -302,7 +302,13 @@ func payoutAndRecon(ctx sdk.Context, k Keeper, bk bank.Keeper, projectDid did.Di
 		return err
 	}
 
-	recipientAddr := did.StringToAddr(recipientDid)
+	// Get recipient address
+	recipientDidDoc, err := k.DidKeeper.GetDidDoc(ctx, recipientDid)
+	if err != nil {
+		return err
+	}
+	recipientAddr := recipientDidDoc.Address()
+
 	err = bk.SendCoins(ctx, fromAccount, recipientAddr, sdk.Coins{amount})
 	if err != nil {
 		return err

--- a/x/project/internal/keeper/keeper.go
+++ b/x/project/internal/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/supply"
 	"github.com/ixofoundation/ixo-blockchain/x/payments"
 
 	"github.com/ixofoundation/ixo-blockchain/x/did"
@@ -17,16 +18,19 @@ type Keeper struct {
 	storeKey       sdk.StoreKey
 	paramSpace     params.Subspace
 	AccountKeeper  auth.AccountKeeper
+	DidKeeper      did.Keeper
 	paymentsKeeper payments.Keeper
 }
 
 func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, paramSpace params.Subspace,
-	accountKeeper auth.AccountKeeper, paymentsKeeper payments.Keeper) Keeper {
+	accountKeeper auth.AccountKeeper, didKeeper did.Keeper,
+	paymentsKeeper payments.Keeper) Keeper {
 	return Keeper{
 		cdc:            cdc,
 		storeKey:       key,
 		paramSpace:     paramSpace.WithKeyTable(types.ParamKeyTable()),
 		AccountKeeper:  accountKeeper,
+		DidKeeper:      didKeeper,
 		paymentsKeeper: paymentsKeeper,
 	}
 }
@@ -148,7 +152,7 @@ func (k Keeper) AddAccountToProjectAccounts(ctx sdk.Context, projectDid did.Did,
 
 func (k Keeper) CreateNewAccount(ctx sdk.Context, projectDid did.Did,
 	accountId types.InternalAccountID) (auth.Account, sdk.Error) {
-	address := did.StringToAddr(accountId.ToAddressKey(projectDid))
+	address := supply.NewModuleAddress(accountId.ToAddressKey(projectDid))
 
 	if k.AccountKeeper.GetAccount(ctx, address) != nil {
 		return nil, sdk.ErrInvalidAddress("Generate account already exists")

--- a/x/project/internal/types/msgs.go
+++ b/x/project/internal/types/msgs.go
@@ -94,7 +94,7 @@ func (msg MsgCreateProject) GetProjectDid() did.Did { return msg.ProjectDid }
 func (msg MsgCreateProject) GetSenderDid() did.Did  { return msg.SenderDid }
 func (msg MsgCreateProject) GetSignerDid() did.Did  { return msg.ProjectDid }
 func (msg MsgCreateProject) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreateProject) String() string {
@@ -162,7 +162,7 @@ func (msg MsgUpdateProjectStatus) GetSignBytes() []byte {
 
 func (msg MsgUpdateProjectStatus) GetSignerDid() did.Did { return msg.ProjectDid }
 func (msg MsgUpdateProjectStatus) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 type MsgCreateAgent struct {
@@ -198,7 +198,7 @@ func (msg MsgCreateAgent) ValidateBasic() sdk.Error {
 
 func (msg MsgCreateAgent) GetSignerDid() did.Did { return msg.ProjectDid }
 func (msg MsgCreateAgent) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreateAgent) GetSignBytes() []byte {
@@ -250,7 +250,7 @@ func (msg MsgUpdateAgent) ValidateBasic() sdk.Error {
 
 func (msg MsgUpdateAgent) GetSignerDid() did.Did { return msg.ProjectDid }
 func (msg MsgUpdateAgent) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgUpdateAgent) GetSignBytes() []byte {
@@ -302,7 +302,7 @@ func (msg MsgCreateClaim) ValidateBasic() sdk.Error {
 
 func (msg MsgCreateClaim) GetSignerDid() did.Did { return msg.ProjectDid }
 func (msg MsgCreateClaim) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreateClaim) GetSignBytes() []byte {
@@ -354,7 +354,7 @@ func (msg MsgCreateEvaluation) ValidateBasic() sdk.Error {
 
 func (msg MsgCreateEvaluation) GetSignerDid() did.Did { return msg.ProjectDid }
 func (msg MsgCreateEvaluation) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgCreateEvaluation) GetSignBytes() []byte {
@@ -418,7 +418,7 @@ func (msg MsgWithdrawFunds) ValidateBasic() sdk.Error {
 
 func (msg MsgWithdrawFunds) GetSignerDid() did.Did { return msg.Data.RecipientDid }
 func (msg MsgWithdrawFunds) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgWithdrawFunds) GetSignBytes() []byte {

--- a/x/treasury/client/cli/tx.go
+++ b/x/treasury/client/cli/tx.go
@@ -33,7 +33,7 @@ func GetCmdSend(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgSend(toDid, coins, ixoDid.Did)
 
@@ -65,7 +65,7 @@ func GetCmdOracleTransfer(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgOracleTransfer(
 				fromDid, toDid, coins, ixoDid.Did, proof)
@@ -97,7 +97,7 @@ func GetCmdOracleMint(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgOracleMint(
 				toDid, coins, ixoDid.Did, proof)
@@ -129,7 +129,7 @@ func GetCmdOracleBurn(cdc *codec.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
-				WithFromAddress(did.DidToAddr(ixoDid.Did))
+				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgOracleBurn(
 				fromDid, coins, ixoDid.Did, proof)

--- a/x/treasury/client/cli/tx.go
+++ b/x/treasury/client/cli/tx.go
@@ -14,11 +14,11 @@ import (
 
 func GetCmdSend(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "send [to-did] [amount] [sender-ixo-did]",
+		Use:   "send [to-did-or-address] [amount] [sender-ixo-did]",
 		Short: "Create and sign a send tx using DIDs",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			toDid := args[0]
+			toDidOrAddr := args[0]
 			coinsStr := args[1]
 			ixoDidStr := args[2]
 
@@ -35,7 +35,7 @@ func GetCmdSend(cdc *codec.Codec) *cobra.Command {
 			cliCtx := context.NewCLIContext().WithCodec(cdc).
 				WithFromAddress(ixoDid.Address())
 
-			msg := types.NewMsgSend(toDid, coins, ixoDid.Did)
+			msg := types.NewMsgSend(toDidOrAddr, coins, ixoDid.Did)
 
 			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, ixoDid)
 		},
@@ -44,12 +44,12 @@ func GetCmdSend(cdc *codec.Codec) *cobra.Command {
 
 func GetCmdOracleTransfer(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "oracle-transfer [from-did] [to-did] [amount] [oracle-ixo-did] [proof]",
+		Use:   "oracle-transfer [from-did] [to-did-or-addr] [amount] [oracle-ixo-did] [proof]",
 		Short: "Create and sign an oracle-transfer tx using DIDs",
 		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fromDid := args[0]
-			toDid := args[1]
+			toDidOrAddr := args[1]
 			coinsStr := args[2]
 			ixoDidStr := args[3]
 			proof := args[4]
@@ -68,7 +68,7 @@ func GetCmdOracleTransfer(cdc *codec.Codec) *cobra.Command {
 				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgOracleTransfer(
-				fromDid, toDid, coins, ixoDid.Did, proof)
+				fromDid, toDidOrAddr, coins, ixoDid.Did, proof)
 
 			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, ixoDid)
 		},
@@ -77,11 +77,11 @@ func GetCmdOracleTransfer(cdc *codec.Codec) *cobra.Command {
 
 func GetCmdOracleMint(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "oracle-mint [to-did] [amount] [oracle-ixo-did] [proof]",
+		Use:   "oracle-mint [to-did-or-addr] [amount] [oracle-ixo-did] [proof]",
 		Short: "Create and sign an oracle-mint tx using DIDs",
 		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			toDid := args[0]
+			toDidOrAddr := args[0]
 			coinsStr := args[1]
 			ixoDidStr := args[2]
 			proof := args[3]
@@ -100,7 +100,7 @@ func GetCmdOracleMint(cdc *codec.Codec) *cobra.Command {
 				WithFromAddress(ixoDid.Address())
 
 			msg := types.NewMsgOracleMint(
-				toDid, coins, ixoDid.Did, proof)
+				toDidOrAddr, coins, ixoDid.Did, proof)
 
 			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, ixoDid)
 		},

--- a/x/treasury/client/rest/tx.go
+++ b/x/treasury/client/rest/tx.go
@@ -25,7 +25,7 @@ func sendRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		toDidParam := r.URL.Query().Get("toDid")
+		toDidOrAddrParam := r.URL.Query().Get("toDidOrAddr")
 		amountParam := r.URL.Query().Get("amount")
 		ixoDidParam := r.URL.Query().Get("ixoDid")
 
@@ -46,7 +46,7 @@ func sendRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		msg := types.NewMsgSend(toDidParam, coins, ixoDid.Did)
+		msg := types.NewMsgSend(toDidOrAddrParam, coins, ixoDid.Did)
 
 		output, err := ixo.CompleteAndBroadcastTxRest(cliCtx, msg, ixoDid)
 		if err != nil {
@@ -65,7 +65,7 @@ func oracleTransferRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 
 		fromDidParam := r.URL.Query().Get("fromDid")
-		toDidParam := r.URL.Query().Get("toDid")
+		toDidOrAddrParam := r.URL.Query().Get("toDidOrAddr")
 		amountParam := r.URL.Query().Get("amount")
 		oracleDidParam := r.URL.Query().Get("oracleDid")
 		proofParam := r.URL.Query().Get("proof")
@@ -88,7 +88,7 @@ func oracleTransferRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		msg := types.NewMsgOracleTransfer(
-			fromDidParam, toDidParam, coins, oracleDid.Did, proofParam)
+			fromDidParam, toDidOrAddrParam, coins, oracleDid.Did, proofParam)
 
 		output, err := ixo.CompleteAndBroadcastTxRest(cliCtx, msg, oracleDid)
 		if err != nil {
@@ -106,7 +106,7 @@ func oracleMintRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		toDidParam := r.URL.Query().Get("toDid")
+		toDidOrAddrParam := r.URL.Query().Get("toDidOrAddr")
 		amountParam := r.URL.Query().Get("amount")
 		oracleDidParam := r.URL.Query().Get("oracleDid")
 		proofParam := r.URL.Query().Get("proof")
@@ -129,7 +129,7 @@ func oracleMintRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		msg := types.NewMsgOracleMint(
-			toDidParam, coins, oracleDid.Did, proofParam)
+			toDidOrAddrParam, coins, oracleDid.Did, proofParam)
 
 		output, err := ixo.CompleteAndBroadcastTxRest(cliCtx, msg, oracleDid)
 		if err != nil {

--- a/x/treasury/handler.go
+++ b/x/treasury/handler.go
@@ -30,7 +30,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 
 func handleMsgSend(ctx sdk.Context, k keeper.Keeper, msg types.MsgSend) sdk.Result {
 
-	if err := k.Send(ctx, msg.FromDid, msg.ToDid, msg.Amount); err != nil {
+	if err := k.Send(ctx, msg.FromDid, msg.ToDidOrAddr, msg.Amount); err != nil {
 		return err.Result()
 	}
 
@@ -46,7 +46,7 @@ func handleMsgSend(ctx sdk.Context, k keeper.Keeper, msg types.MsgSend) sdk.Resu
 
 func handleMsgOracleTransfer(ctx sdk.Context, k keeper.Keeper, msg types.MsgOracleTransfer) sdk.Result {
 
-	if err := k.OracleTransfer(ctx, msg.FromDid, msg.ToDid, msg.OracleDid, msg.Amount); err != nil {
+	if err := k.OracleTransfer(ctx, msg.FromDid, msg.ToDidOrAddr, msg.OracleDid, msg.Amount); err != nil {
 		return err.Result()
 	}
 
@@ -62,7 +62,7 @@ func handleMsgOracleTransfer(ctx sdk.Context, k keeper.Keeper, msg types.MsgOrac
 
 func handleMsgOracleMint(ctx sdk.Context, k keeper.Keeper, msg types.MsgOracleMint) sdk.Result {
 
-	if err := k.OracleMint(ctx, msg.OracleDid, msg.ToDid, msg.Amount); err != nil {
+	if err := k.OracleMint(ctx, msg.OracleDid, msg.ToDidOrAddr, msg.Amount); err != nil {
 		return err.Result()
 	}
 

--- a/x/treasury/internal/types/msgs.go
+++ b/x/treasury/internal/types/msgs.go
@@ -56,7 +56,7 @@ func (msg MsgSend) ValidateBasic() sdk.Error {
 
 func (msg MsgSend) GetSignerDid() did.Did { return msg.FromDid }
 func (msg MsgSend) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgSend) String() string {
@@ -116,7 +116,7 @@ func (msg MsgOracleTransfer) ValidateBasic() sdk.Error {
 
 func (msg MsgOracleTransfer) GetSignerDid() did.Did { return msg.OracleDid }
 func (msg MsgOracleTransfer) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgOracleTransfer) String() string {
@@ -171,7 +171,7 @@ func (msg MsgOracleMint) ValidateBasic() sdk.Error {
 
 func (msg MsgOracleMint) GetSignerDid() did.Did { return msg.OracleDid }
 func (msg MsgOracleMint) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgOracleMint) String() string {
@@ -226,7 +226,7 @@ func (msg MsgOracleBurn) ValidateBasic() sdk.Error {
 
 func (msg MsgOracleBurn) GetSignerDid() did.Did { return msg.OracleDid }
 func (msg MsgOracleBurn) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{did.DidToAddr(msg.GetSignerDid())}
+	panic("tried to use unimplemented GetSigners function")
 }
 
 func (msg MsgOracleBurn) String() string {

--- a/x/treasury/internal/types/msgs.go
+++ b/x/treasury/internal/types/msgs.go
@@ -24,9 +24,9 @@ var (
 )
 
 type MsgSend struct {
-	FromDid did.Did   `json:"from_did" yaml:"from_did"`
-	ToDid   did.Did   `json:"to_did" yaml:"to_did"`
-	Amount  sdk.Coins `json:"amount" yaml:"amount"`
+	FromDid     did.Did   `json:"from_did" yaml:"from_did"`
+	ToDidOrAddr did.Did   `json:"to_did" yaml:"to_did"`
+	Amount      sdk.Coins `json:"amount" yaml:"amount"`
 }
 
 func (msg MsgSend) Type() string  { return TypeMsgSend }
@@ -35,15 +35,17 @@ func (msg MsgSend) ValidateBasic() sdk.Error {
 	// Check that not empty
 	if valid, err := CheckNotEmpty(msg.FromDid, "FromDid"); !valid {
 		return err
-	} else if valid, err = CheckNotEmpty(msg.ToDid, "ToDid"); !valid {
+	} else if valid, err = CheckNotEmpty(msg.ToDidOrAddr, "ToDidOrAddr"); !valid {
 		return err
 	}
 
-	// Check that DIDs valid
+	// Check that DIDs/addresses valid
 	if !did.IsValidDid(msg.FromDid) {
 		return did.ErrorInvalidDid(DefaultCodespace, "from did is invalid")
-	} else if !did.IsValidDid(msg.ToDid) {
-		return did.ErrorInvalidDid(DefaultCodespace, "to did is invalid")
+	}
+	_, err := sdk.AccAddressFromBech32(msg.ToDidOrAddr)
+	if err != nil && !did.IsValidDid(msg.ToDidOrAddr) {
+		return sdk.ErrInvalidAddress("recipient is neither a did nor an address")
 	}
 
 	// Check amount (note: validity also checks that coins are positive)
@@ -76,11 +78,11 @@ func (msg MsgSend) GetSignBytes() []byte {
 }
 
 type MsgOracleTransfer struct {
-	OracleDid did.Did   `json:"oracle_did" yaml:"oracle_did"`
-	FromDid   did.Did   `json:"from_did" yaml:"from_did"`
-	ToDid     did.Did   `json:"to_did" yaml:"to_did"`
-	Amount    sdk.Coins `json:"amount" yaml:"amount"`
-	Proof     string    `json:"proof" yaml:"proof"`
+	OracleDid   did.Did   `json:"oracle_did" yaml:"oracle_did"`
+	FromDid     did.Did   `json:"from_did" yaml:"from_did"`
+	ToDidOrAddr did.Did   `json:"to_did" yaml:"to_did"`
+	Amount      sdk.Coins `json:"amount" yaml:"amount"`
+	Proof       string    `json:"proof" yaml:"proof"`
 }
 
 func (msg MsgOracleTransfer) Type() string  { return TypeMsgOracleTransfer }
@@ -91,19 +93,21 @@ func (msg MsgOracleTransfer) ValidateBasic() sdk.Error {
 		return err
 	} else if valid, err := CheckNotEmpty(msg.FromDid, "FromDid"); !valid {
 		return err
-	} else if valid, err := CheckNotEmpty(msg.ToDid, "ToDid"); !valid {
+	} else if valid, err := CheckNotEmpty(msg.ToDidOrAddr, "ToDidOrAddr"); !valid {
 		return err
 	} else if valid, err := CheckNotEmpty(msg.Proof, "Proof"); !valid {
 		return err
 	}
 
-	// Check that DIDs valid
+	// Check that DIDs/addresses valid
 	if !did.IsValidDid(msg.OracleDid) {
 		return did.ErrorInvalidDid(DefaultCodespace, "oracle did is invalid")
 	} else if !did.IsValidDid(msg.FromDid) {
 		return did.ErrorInvalidDid(DefaultCodespace, "from did is invalid")
-	} else if !did.IsValidDid(msg.ToDid) {
-		return did.ErrorInvalidDid(DefaultCodespace, "to did is invalid")
+	}
+	_, err := sdk.AccAddressFromBech32(msg.ToDidOrAddr)
+	if err != nil && !did.IsValidDid(msg.ToDidOrAddr) {
+		return sdk.ErrInvalidAddress("recipient is neither a did nor an address")
 	}
 
 	// Check amount (note: validity also checks that coins are positive)
@@ -136,10 +140,10 @@ func (msg MsgOracleTransfer) GetSignBytes() []byte {
 }
 
 type MsgOracleMint struct {
-	OracleDid did.Did   `json:"oracle_did" yaml:"oracle_did"`
-	ToDid     did.Did   `json:"to_did" yaml:"to_did"`
-	Amount    sdk.Coins `json:"amount" yaml:"amount"`
-	Proof     string    `json:"proof" yaml:"proof"`
+	OracleDid   did.Did   `json:"oracle_did" yaml:"oracle_did"`
+	ToDidOrAddr did.Did   `json:"to_did" yaml:"to_did"`
+	Amount      sdk.Coins `json:"amount" yaml:"amount"`
+	Proof       string    `json:"proof" yaml:"proof"`
 }
 
 func (msg MsgOracleMint) Type() string  { return TypeMsgOracleMint }
@@ -148,17 +152,19 @@ func (msg MsgOracleMint) ValidateBasic() sdk.Error {
 	// Check that not empty
 	if valid, err := CheckNotEmpty(msg.OracleDid, "OracleDid"); !valid {
 		return err
-	} else if valid, err := CheckNotEmpty(msg.ToDid, "ToDid"); !valid {
+	} else if valid, err := CheckNotEmpty(msg.ToDidOrAddr, "ToDidOrAddr"); !valid {
 		return err
 	} else if valid, err := CheckNotEmpty(msg.Proof, "Proof"); !valid {
 		return err
 	}
 
-	// Check that DIDs valid
+	// Check that DIDs/addresses valid
 	if !did.IsValidDid(msg.OracleDid) {
 		return did.ErrorInvalidDid(DefaultCodespace, "oracle did is invalid")
-	} else if !did.IsValidDid(msg.ToDid) {
-		return did.ErrorInvalidDid(DefaultCodespace, "to did is invalid")
+	}
+	_, err := sdk.AccAddressFromBech32(msg.ToDidOrAddr)
+	if err != nil && !did.IsValidDid(msg.ToDidOrAddr) {
+		return sdk.ErrInvalidAddress("recipient is neither a did nor an address")
 	}
 
 	// Check amount (note: validity also checks that coins are positive)

--- a/x/treasury/internal/types/util.go
+++ b/x/treasury/internal/types/util.go
@@ -6,32 +6,32 @@ import (
 	"strings"
 )
 
-func NewMsgSend(toDid did.Did, amount sdk.Coins, senderDid did.Did) MsgSend {
+func NewMsgSend(toDidOrAddr string, amount sdk.Coins, senderDid did.Did) MsgSend {
 	return MsgSend{
-		FromDid: senderDid,
-		ToDid:   toDid,
-		Amount:  amount,
+		FromDid:     senderDid,
+		ToDidOrAddr: toDidOrAddr,
+		Amount:      amount,
 	}
 }
 
-func NewMsgOracleTransfer(fromDid, toDid did.Did, amount sdk.Coins,
+func NewMsgOracleTransfer(fromDid did.Did, toDidOrAddr string, amount sdk.Coins,
 	oracleDid did.Did, proof string) MsgOracleTransfer {
 	return MsgOracleTransfer{
-		OracleDid: oracleDid,
-		FromDid:   fromDid,
-		ToDid:     toDid,
-		Amount:    amount,
-		Proof:     proof,
+		OracleDid:   oracleDid,
+		FromDid:     fromDid,
+		ToDidOrAddr: toDidOrAddr,
+		Amount:      amount,
+		Proof:       proof,
 	}
 }
 
-func NewMsgOracleMint(toDid did.Did, amount sdk.Coins,
+func NewMsgOracleMint(toDidOrAddr string, amount sdk.Coins,
 	oracleDid did.Did, proof string) MsgOracleMint {
 	return MsgOracleMint{
-		OracleDid: oracleDid,
-		ToDid:     toDid,
-		Amount:    amount,
-		Proof:     proof,
+		OracleDid:   oracleDid,
+		ToDidOrAddr: toDidOrAddr,
+		Amount:      amount,
+		Proof:       proof,
 	}
 }
 

--- a/x/treasury/spec/01_messages.md
+++ b/x/treasury/spec/01_messages.md
@@ -1,10 +1,12 @@
 # Messages
 
-In this section we describe the processing of the treasury messages and the corresponding updates to the state. The treasury module does not store any state itself. Whenever conversion from DID to address is mentioned, this is being performed as follows:
+In this section we describe the processing of the treasury messages and the corresponding updates to the state. The treasury module does not store any state itself. Whenever conversion from DID to address is mentioned, this is being performed using the public key as follows:
 
 ```go
-func DidToAddr(did did.Did) sdk.AccAddress {
-	return sdk.AccAddress(crypto.AddressHash([]byte(did)))
+func VerifyKeyToAddr(verifyKey string) sdk.AccAddress {
+	var pubKey ed25519.PubKeyEd25519
+	copy(pubKey[:], base58.Decode(verifyKey))
+	return sdk.AccAddress(pubKey.Address())
 }
 ```
 


### PR DESCRIPTION
Closes #145 

- Replaced `DidToAddr()` mapping with address from ED25519 pubkey
- Replaced `StringToAddr()` with `supply.NewModuleAddress`
- GetSignData now takes a pubkey, in order to be able to find the signer's address
- Added _address-from-pubkey_ CLI and REST queries
- Queries _address-from-did_ now deduce the address from the stored DID doc's pubkey