### PR TITLE
Bonds Count Improvements

### DIFF
--- a/x/bonds/client/cli/tx.go
+++ b/x/bonds/client/cli/tx.go
@@ -98,7 +98,7 @@ func GetCmdCreateBond(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			// parse sanity rate
+			// Parse sanity rate
 			sanityRate, err := sdk.NewDecFromStr(_sanityRate)
 			if err != nil {
 				return fmt.Errorf(err.Error())

--- a/x/bonds/client/rest/tx.go
+++ b/x/bonds/client/rest/tx.go
@@ -123,7 +123,7 @@ func createBondHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		// parse sanity rate
+		// Parse sanity rate
 		sanityRate, err := sdk.NewDecFromStr(req.SanityRate)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -3,6 +3,7 @@ package bonds
 import (
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/supply"
 	"github.com/ixofoundation/ixo-blockchain/x/bonds/internal/keeper"
 	"github.com/ixofoundation/ixo-blockchain/x/bonds/internal/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -71,7 +72,8 @@ func handleMsgCreateBond(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgCre
 		return types.ErrBondTokenCannotBeStakingToken(DefaultCodespace).Result()
 	}
 
-	reserveAddress := keeper.GetNextUnusedReserveAddress(ctx)
+	reserveAddress := supply.NewModuleAddress(
+		fmt.Sprintf("bonds/%s/reserveAddress", msg.BondDid))
 
 	// TODO: investigate ways to prevent reserve address from receiving transactions
 

--- a/x/bonds/internal/keeper/bonds.go
+++ b/x/bonds/internal/keeper/bonds.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"bytes"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ixofoundation/ixo-blockchain/x/bonds/internal/types"
@@ -11,42 +10,6 @@ import (
 func (k Keeper) GetBondIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
 	return sdk.KVStorePrefixIterator(store, types.BondsKeyPrefix)
-}
-
-func (k Keeper) GetNumberOfBonds(ctx sdk.Context) sdk.Int {
-	count := sdk.ZeroInt()
-	iterator := k.GetBondIterator(ctx)
-	for ; iterator.Valid(); iterator.Next() {
-		var bond types.Bond
-		k.cdc.MustUnmarshalBinaryBare(iterator.Value(), &bond)
-		count = count.AddRaw(1)
-	}
-	return count
-}
-
-func (k Keeper) GetReserveAddressByBondCount(count sdk.Int) sdk.AccAddress {
-	var buffer bytes.Buffer
-
-	// Start with number of bonds prefixed with a letter (in this case, A)
-	// Letter is added to separate the number from possible digits
-	numString := "A" + count.String()
-
-	// Append numString to a base HEX address
-	buffer.WriteString("A97B2E13A94AF4A1D3EC729DC422C6341BAEEDC9")
-	buffer.WriteString(numString)
-
-	// Truncate from the front to the required length (38) and parse to address
-	truncated := buffer.String()[len(buffer.String())-40:]
-	res, err := sdk.AccAddressFromHex(truncated)
-	if err != nil {
-		panic(err)
-	}
-
-	return res
-}
-
-func (k Keeper) GetNextUnusedReserveAddress(ctx sdk.Context) sdk.AccAddress {
-	return k.GetReserveAddressByBondCount(k.GetNumberOfBonds(ctx))
 }
 
 func (k Keeper) GetBond(ctx sdk.Context, bondDid did.Did) (bond types.Bond, found bool) {


### PR DESCRIPTION
Closes #103 

Bond reserve address now deduced from hash of string involving bond DID rather than a bond counter.