### PR TITLE
v0.39.x Finishing Touches

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -481,9 +481,41 @@ func GetMaccPerms() map[string][]string {
 
 func NewIxoAnteHandler(app *ixoApp) sdk.AnteHandler {
 
-	defaultPubKeyGetter := ixo.NewDefaultPubKeyGetter(app.didKeeper)
-	didPubKeyGetter := did.GetPubKeyGetter(app.didKeeper)
-	projectPubKeyGetter := project.GetPubKeyGetter(app.projectKeeper, app.didKeeper)
+	// The AnteHandler needs to get the signer's pubkey to verify signatures,
+	// charge gas fees (to the corresponding address), and for other purposes.
+	//
+	// The default Cosmos AnteHandler fetches a signer address' pubkey from the
+	// GetPubKey() function after querying the account from the account keeper.
+	//
+	// In the case of ixo, since signers are DIDs rather than addresses, we get
+	// the DID Doc containing the pubkey from the did/project module (depending
+	// if signer is a user or a project, respectively).
+	//
+	// This is what PubKeyGetters achieve.
+	//
+	// To get a pubkey from the did/project, the did/project must have been
+	// created. But during the did/project creation, we also need the pubkeys,
+	// which we cannot get because the did/project does not even exist yet.
+	// For this purpose, a special didPubKeyGetter and projectPubkeyGetter were
+	// created, which get the pubkey from the did/project creation msg itself,
+	// given that the pubkey is one of the parameters in such messages.
+	//
+	// - did module msgs are signed by did module DIDs
+	// - project module msgs are signed by project module DIDs (a.k.a projects)
+	// - [[default]] remaining ixo module msgs are signed by did module DIDs
+	//
+	// A special case in the project module is the MsgWithdrawFunds message,
+	// which is a project module message signed by a did module DID (instead
+	// of a project DID). The project module PubKeyGetter deals with this
+	// inconsistency by using the did module pubkey getter for MsgWithdrawFunds.
+
+	defaultPubKeyGetter := did.NewDefaultPubKeyGetter(app.didKeeper)
+	didPubKeyGetter := did.NewModulePubKeyGetter(app.didKeeper)
+	projectPubKeyGetter := project.NewModulePubKeyGetter(app.projectKeeper, app.didKeeper)
+
+	// Since we have parameterised pubkey getters, we can use the same default
+	// ixo AnteHandler (ixo.NewDefaultAnteHandler) for all three pubkey getters
+	// instead of having to implement three unique AnteHandlers.
 
 	defaultIxoAnteHandler := ixo.NewDefaultAnteHandler(
 		app.AccountKeeper, app.SupplyKeeper, ixo.IxoSigVerificationGasConsumer, defaultPubKeyGetter)
@@ -491,8 +523,30 @@ func NewIxoAnteHandler(app *ixoApp) sdk.AnteHandler {
 		app.AccountKeeper, app.SupplyKeeper, ixo.IxoSigVerificationGasConsumer, didPubKeyGetter)
 	projectAnteHandler := ixo.NewDefaultAnteHandler(
 		app.AccountKeeper, app.SupplyKeeper, ixo.IxoSigVerificationGasConsumer, projectPubKeyGetter)
+
+	// The default Cosmos AnteHandler is still used for standard Cosmos messages
+	// implemented in standard Cosmos modules (bank, gov, etc.). The only change
+	// is that we use an IxoSigVerificationGasConsumer instead of the default
+	// one, since the default does not allow ED25519 signatures. Thus, like this
+	// we enable ED25519 (as well as Secp) signing of standard Cosmos messages.
+
 	cosmosAnteHandler := auth.NewAnteHandler(
 		app.AccountKeeper, app.SupplyKeeper, ixo.IxoSigVerificationGasConsumer)
+
+	// In the case of project creation, besides having a custom pubkey getter,
+	// we also have to use a custom project creation AnteHandler. Recall that
+	// one of the purposes of getting the pubkey is to charge gas fees. So we
+	// expect the signer to have enough tokens to pay for gas fees. Typically,
+	// these are sent to the signer before the signer signs their first message.
+	//
+	// However, in the case of a project, we cannot send tokens to it before its
+	// creation since we do not know the project DID (and thus where to send the
+	// tokens) until exactly before its creation (when project creation is done
+	// through ixo-cellnode). The project however does have an original creator!
+	//
+	// Thus, the gas fees in the case of project creation are instead charged
+	// to the original creator, which is pointed out in the project doc. For
+	// this purpose, a custom project creation AnteHandler had to be created.
 
 	projectCreationAnteHandler := project.NewProjectCreationAnteHandler(
 		app.AccountKeeper, app.SupplyKeeper, app.BankKeeper,

--- a/scripts/demo_project_x_bonds.sh
+++ b/scripts/demo_project_x_bonds.sh
@@ -21,8 +21,8 @@ fi
 
 PASSWORD="12345678"
 GAS_PRICES="0.025uixo"
-yes $PASSWORD | ixocli keys delete fee --force
-yes $PASSWORD | ixocli keys add fee
+yes $PASSWORD | ixocli keys delete fee --force > /dev/null 2>&1
+yes $PASSWORD | ixocli keys add fee > /dev/null 2>&1
 FEE=$(yes $PASSWORD | ixocli keys show fee -a)
 
 IXO_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"
@@ -135,10 +135,10 @@ ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-p
 ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $OWNER_DID_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
 
 # Each DID including the owner now has 10IXO for gas fees 
-DID_1_ADDR=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_1_FULL)")
-ixocli q account $DID_1_ADDR
-OWNER_ADDR=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $OWNER_DID_FULL)")
-ixocli q account $OWNER_ADDR
+# DID_1_ADDR=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_1_FULL)")
+# ixocli q account $DID_1_ADDR
+# OWNER_ADDR=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $OWNER_DID_FULL)")
+# ixocli q account $OWNER_ADDR
 
 # Ledger the 10 DIDs and owner DID
 echo "Ledgering DIDs..."
@@ -165,7 +165,7 @@ ixocli tx treasury oracle-mint "$OWNER_ADDR" 300000000uxgbp "$ORACLE_DID_FULL" "
 
 # Owner now has 300xGBP to use in the project
 # Side note: we can now query the account using just the DID instead of using get_pubkey.js, since the DID has been registered.
-ixocli q account "$(ixocli q did get-address-from-did $OWNER_DID)"
+# ixocli q account "$(ixocli q did get-address-from-did $OWNER_DID)"
 
 # Create bond
 echo "Creating bond..."
@@ -187,17 +187,17 @@ ixocli tx bonds create-bond \
   --outcome-payment="300000000uxgbp" \
   --bond-did="$BOND_DID" \
   --creator-did="$OWNER_DID_FULL" \
-  --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+  --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
 
 # Create oracle fee payment template
 echo "Creating oracle fee payment template..."
 CREATOR="$IXO_DID_FULL"
-ixocli tx payments create-payment-template "$ORACLE_FEE_PAYMENT_TEMPLATE" "$CREATOR" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+ixocli tx payments create-payment-template "$ORACLE_FEE_PAYMENT_TEMPLATE" "$CREATOR" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
 
 # Create fee-for-service payment template
 echo "Creating fee-for-service payment template..."
 CREATOR="$IXO_DID_FULL"
-ixocli tx payments create-payment-template "$FEE_FOR_SERVICE_PAYMENT_TEMPLATE" "$CREATOR" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+ixocli tx payments create-payment-template "$FEE_FOR_SERVICE_PAYMENT_TEMPLATE" "$CREATOR" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
 
 # Create project and progress status to PENDING
 SENDER_DID="$OWNER_DID"
@@ -249,7 +249,7 @@ ixocli tx project create-evaluation "tx_hash" "$DID_9" "claim9" "$STATUS" "$PROJ
 ixocli tx project create-evaluation "tx_hash" "$DID_10" "claim10" "$STATUS" "$PROJECT_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
 
 # Each of the 10 DIDs now has 1xGBP (1000000uxgbp)
-ixocli q account "$(ixocli q did get-address-from-did "$DID_1")"
+# ixocli q account "$(ixocli q did get-address-from-did "$DID_1")"
 
 # Perform bond buys
 echo "DID 1 buys 1ABC..."

--- a/scripts/demo_project_x_bonds.sh
+++ b/scripts/demo_project_x_bonds.sh
@@ -122,17 +122,28 @@ ixocli tx did add-did-doc "$IXO_DID_FULL" --broadcast-mode block --gas-prices="$
 
 # Fund DID and owner accounts using ixo DID for gas fees
 echo "Funding DID and owner accounts..."
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_1_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_2_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_3_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_4_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_5_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_6_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_7_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_8_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_9_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_10_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
-ixocli tx treasury oracle-transfer "$IXO_DID" "$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $OWNER_DID_FULL)")" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ADDR1=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_1_FULL")")
+ADDR2=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_2_FULL")")
+ADDR3=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_3_FULL")")
+ADDR4=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_4_FULL")")
+ADDR5=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_5_FULL")")
+ADDR6=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_6_FULL")")
+ADDR7=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_7_FULL")")
+ADDR8=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_8_FULL")")
+ADDR9=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$DID_9_FULL")")
+ADDR10=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_10_FULL)")
+OWNER_ADDR=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js "$OWNER_DID_FULL")")
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR1" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR2" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR3" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR4" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR5" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR6" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR7" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR8" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR9" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$ADDR10" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
+ixocli tx treasury oracle-transfer "$IXO_DID" "$OWNER_ADDR" 10000000uixo "$ORACLE_DID_FULL" "proof" --broadcast-mode block --gas-prices="$GAS_PRICES" -y > /dev/null
 
 # Each DID including the owner now has 10IXO for gas fees 
 # DID_1_ADDR=$(ixocli q did get-address-from-pubkey "$(node utils/get_pubkey.js $DID_1_FULL)")

--- a/scripts/events_extractor.py
+++ b/scripts/events_extractor.py
@@ -1,12 +1,11 @@
+import requests
 from base64 import b64decode
 from typing import List, Dict
 from urllib.parse import quote
 
-import requests
-
 URL = "http://localhost:26657"
 IGNORED_EVENTS = \
-    ["message", "transfer", "commission", "rewards", "proposer_reward"]
+    ["message", "transfer", "commission", "rewards", "proposer_reward", "mint"]
 
 
 def print_events(events: List[Dict]):
@@ -26,15 +25,18 @@ def print_events(events: List[Dict]):
 for height in range(1, 100):
     # Block events
     res = requests.get("{}/block_results?height={}".format(URL, height)).json()
-    sections = ['begin_block', 'end_block']
+    sections = ['begin_block_events', 'end_block_events']
     for section in sections:
-        res_section = res['result']['results'][section]
-        if 'events' in res_section:
-            print_events(res_section['events'])
+        if res['result'][section]:
+            print_events(res['result'][section])
 
     # Transaction events
     query = quote("\"tx.height={}\"".format(height))
-    params = "query=" + query + "&prove=true&page=1&per_page=30&order_by=asc"
+    params = "query={}&" \
+             "\"prove=true\"&" \
+             "\"page=1\"&" \
+             "\"per_page=30\"&" \
+             "\"order_by=asc\"".format(query)
     res = requests.get("{}/tx_search?{}".format(URL, params)).json()
     for tx in res['result']['txs']:
         print_events(tx['tx_result']['events'])

--- a/scripts/events_extractor.py
+++ b/scripts/events_extractor.py
@@ -25,8 +25,13 @@ def print_events(events: List[Dict]):
 for height in range(1, 100):
     # Block events
     res = requests.get("{}/block_results?height={}".format(URL, height)).json()
-    sections = ['begin_block_events', 'end_block_events']
-    for section in sections:
+
+    if 'error' in res and 'must be less than or equal to the current ' \
+                          'blockchain height' in res['error']['data']:
+        print('\nReached last height; stopping!')
+        break
+
+    for section in ['begin_block_events', 'end_block_events']:
         if res['result'][section]:
             print_events(res['result'][section])
 

--- a/x/ixo/alias.go
+++ b/x/ixo/alias.go
@@ -15,7 +15,6 @@ var (
 	RegisterCodec = types.RegisterCodec
 
 	// Auth
-	NewDefaultPubKeyGetter           = types.NewDefaultPubKeyGetter
 	NewDefaultAnteHandler            = types.NewDefaultAnteHandler
 	ProcessSig                       = types.ProcessSig
 	NewSetPubKeyDecorator            = types.NewSetPubKeyDecorator

--- a/x/ixo/alias.go
+++ b/x/ixo/alias.go
@@ -16,7 +16,6 @@ var (
 
 	// Auth
 	NewDefaultAnteHandler            = types.NewDefaultAnteHandler
-	ProcessSig                       = types.ProcessSig
 	NewSetPubKeyDecorator            = types.NewSetPubKeyDecorator
 	NewDeductFeeDecorator            = types.NewDeductFeeDecorator
 	NewSigGasConsumeDecorator        = types.NewSigGasConsumeDecorator

--- a/x/ixo/internal/types/auth.go
+++ b/x/ixo/internal/types/auth.go
@@ -44,20 +44,6 @@ func init() {
 
 type PubKeyGetter func(ctx sdk.Context, msg IxoMsg) (crypto.PubKey, error)
 
-func NewDefaultPubKeyGetter(didKeeper DidKeeper) PubKeyGetter {
-	return func(ctx sdk.Context, msg IxoMsg) (pubKey crypto.PubKey, err error) {
-
-		signerDidDoc, err := didKeeper.GetDidDoc(ctx, msg.GetSignerDid())
-		if err != nil {
-			return pubKey, err
-		}
-
-		var pubKeyRaw ed25519tm.PubKeyEd25519
-		copy(pubKeyRaw[:], base58.Decode(signerDidDoc.GetPubKey()))
-		return pubKeyRaw, nil
-	}
-}
-
 func NewDefaultAnteHandler(ak auth.AccountKeeper, supplyKeeper supply.Keeper, sigGasConsumer ante.SignatureVerificationGasConsumer, pubKeyGetter PubKeyGetter) sdk.AnteHandler {
 	return sdk.ChainAnteDecorators(
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first

--- a/x/ixo/internal/types/decorators.go
+++ b/x/ixo/internal/types/decorators.go
@@ -33,7 +33,7 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	// all messages must be of type IxoMsg
 	msg, ok := tx.GetMsgs()[0].(IxoMsg)
 	if !ok {
-		return ctx, fmt.Errorf("msg must be ixo.IxoMsg")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be ixo.IxoMsg")
 	}
 
 	// Get pubKey
@@ -111,7 +111,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	// all messages must be of type IxoMsg
 	msg, ok := tx.GetMsgs()[0].(IxoMsg)
 	if !ok {
-		return ctx, fmt.Errorf("msg must be ixo.IxoMsg")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be ixo.IxoMsg")
 	}
 
 	// Get pubKey
@@ -169,7 +169,7 @@ func (sgcd SigGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	// all messages must be of type IxoMsg
 	msg, ok := tx.GetMsgs()[0].(IxoMsg)
 	if !ok {
-		return ctx, fmt.Errorf("msg must be ixo.IxoMsg")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be ixo.IxoMsg")
 	}
 
 	// Get pubKey
@@ -240,7 +240,7 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	// all messages must be of type IxoMsg
 	msg, ok := tx.GetMsgs()[0].(IxoMsg)
 	if !ok {
-		return ctx, fmt.Errorf("msg must be ixo.IxoMsg")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be ixo.IxoMsg")
 	}
 
 	// Get pubKey
@@ -312,7 +312,7 @@ func (isd IncrementSequenceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 	// all messages must be of type IxoMsg
 	msg, ok := tx.GetMsgs()[0].(IxoMsg)
 	if !ok {
-		return ctx, fmt.Errorf("msg must be ixo.IxoMsg")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be ixo.IxoMsg")
 	}
 
 	// Get pubKey

--- a/x/project/auth.go
+++ b/x/project/auth.go
@@ -92,7 +92,9 @@ func deductProjectFundingFees(bankKeeper bank.Keeper, ctx sdk.Context,
 	return nil
 }
 
-func getProjectCreationSignBytes(chainID string, tx auth.StdTx, acc exported.Account, genesis bool) []byte {
+func getProjectCreationSignBytes(ctx sdk.Context, tx auth.StdTx, acc exported.Account) []byte {
+	genesis := ctx.BlockHeight() == 0
+	chainID := ctx.ChainID()
 	var accNum uint64
 	if !genesis {
 		// Fixed account number used so that sign bytes do not depend on it

--- a/x/project/decorators.go
+++ b/x/project/decorators.go
@@ -7,6 +7,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
@@ -229,9 +230,6 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 		if err != nil {
 			return ctx, err
 		}
-
-		// reload the account as fees have been deducted
-		feePayerAcc = dfd.ak.GetAccount(ctx, feePayerAcc.GetAddress())
 	}
 
 	return next(ctx, tx, simulate)
@@ -264,6 +262,10 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
 	}
 
+	// stdSigs contains the sequence number, account number, and signatures.
+	// When simulating, this would just be a 0-length slice.
+	sigs := sigTx.GetSignatures()
+
 	// message must be of type MsgCreateProject
 	msg, ok := tx.GetMsgs()[0].(MsgCreateProject)
 	if !ok {
@@ -277,27 +279,40 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	}
 
 	// Fetch signer (account underlying DID). Account expected to not exist
-	signerAddr := sdk.AccAddress(pubKey.Address())
-	signerAcc, err := ante.GetSignerAcc(ctx, svd.ak, signerAddr)
-	if err != nil {
-		return ctx, err
+	signerAddrs := []sdk.AccAddress{sdk.AccAddress(pubKey.Address())}
+	signerAccs := make([]authexported.Account, len(signerAddrs))
+
+	// check that signer length and signature length are the same
+	if len(sigs) != len(signerAddrs) {
+		return ctx, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "invalid number of signer;  expected: %d, got %d", len(signerAddrs), len(sigs))
 	}
 
-	// check signature, return account with incremented nonce
-	stdTx, ok := tx.(auth.StdTx)
-	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
-	}
-	ixoSig := auth.StdSignature{PubKey: pubKey, Signature: sigTx.GetSignatures()[0]}
-	isGenesis := ctx.BlockHeight() == 0
-	params := svd.ak.GetParams(ctx)
-	signBytes := getProjectCreationSignBytes(ctx.ChainID(), stdTx, signerAcc, isGenesis)
-	signerAcc, err = ixo.ProcessSig(ctx, signerAcc, ixoSig, signBytes, simulate, params)
-	if err != nil {
-		return ctx, err
-	}
+	for i, sig := range sigs {
+		signerAccs[i], err = ante.GetSignerAcc(ctx, svd.ak, signerAddrs[i])
+		if err != nil {
+			return ctx, err
+		}
 
-	svd.ak.SetAccount(ctx, signerAcc)
+		// check signature, return account with incremented nonce
+		stdTx, ok := tx.(auth.StdTx)
+		if !ok {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+		}
+
+		// retrieve signBytes of tx
+		signBytes := getProjectCreationSignBytes(ctx, stdTx, signerAccs[i])
+
+		// retrieve pubkey
+		pubKey := signerAccs[i].GetPubKey()
+		if !simulate && pubKey == nil {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
+		}
+
+		// verify signature
+		if !simulate && !pubKey.VerifyBytes(signBytes, sig) {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "signature verification failed; verify correct account sequence and chain-id")
+		}
+	}
 
 	return next(ctx, tx, simulate)
 }

--- a/x/project/decorators.go
+++ b/x/project/decorators.go
@@ -174,7 +174,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	// all messages must be of type MsgCreateProject
 	msg, ok := tx.GetMsgs()[0].(MsgCreateProject)
 	if !ok {
-		return ctx, fmt.Errorf("msg must be MsgCreateProject")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be MsgCreateProject")
 	}
 
 	// Get pubKey
@@ -267,7 +267,7 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	// message must be of type MsgCreateProject
 	msg, ok := tx.GetMsgs()[0].(MsgCreateProject)
 	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be ixo.MsgCreateProject")
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "msg must be MsgCreateProject")
 	}
 
 	// Get did pubKey


### PR DESCRIPTION
Main changes:
- `PubKeyGetter` normalisation
  - Renamed _did_ & _project_ modules' `GetPubKeyGetter` to `NewModulePubKeyGetter`
  - _did_ & _project_ modules now have a similar `NewDefaultPubKeyGetter`.
    - The _did_ module's default `PubKeyGetter` replaces the previous _ixo_ module `PubKeyGetter`
- ProjectCreationAnteHandler:
  - Project module `SigVerificationDecorator` is now closer to the default ixo `SigVerificationDecorator`
  - Removed extra `ProcessSig` function, which was only used by project `SigVerificationDecorator` and caused duplicate (pubkey setting and sequence number incrementation) functionality.
  - `getProjectCreationSignBytes` is now also closer to the default `GetSignBytes` function.
- Inline documentation:
  - Added doc to `NewIxoAnteHandler` explaining at a high-level why we need custom AnteHandlers
  - Added doc to AnteHandlers (both the default ixo AnteHandler, and the project creation AnteHandler)

Other:
- Changes to project_x_bonds demo:
  - Shut off remaining outputs for consistency, except for demo narration
  - Parameterised addresses in funding step, for readability
- Updated events extractor script to work with 0.39.x
- `Errorf`: use of specific errors instead of `Errorf` in some cases