### PR TITLE
Fix project minimum funding check not working

### DIFF
--- a/x/project/handler.go
+++ b/x/project/handler.go
@@ -125,8 +125,14 @@ func handleMsgUpdateProjectStatus(ctx sdk.Context, k Keeper, bk bank.Keeper,
 				"could not find project's account with address %s", projectAddr)
 		}
 
+		// Two conditions for minimum funding not reached:
+		// - Either minimumFunding has some denom that is not in the projectAcc
+		//   coins, indicating that the projectAcc has zero of this denom
+		// - Or minimumFunding has some denom with a larger value than the projectAcc
+		//   coins, indicating that the projectAcc has less than the minimum
 		minimumFunding := k.GetParams(ctx).ProjectMinimumInitialFunding
-		if minimumFunding.IsAnyGT(projectAcc.GetCoins()) {
+		if !minimumFunding.DenomsSubsetOf(projectAcc.GetCoins()) ||
+			minimumFunding.IsAnyGT(projectAcc.GetCoins()) {
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds,
 				"project has not reached minimum funding %s", minimumFunding)
 		}


### PR DESCRIPTION
Closes #208 

To fix the project minimum funding check, the check was changed from:
```
if minimumFunding.IsAnyGT(projectAcc.GetCoins()) {
    // Project does NOT have enough funding
}
```

To:
```
if !minimumFunding.DenomsSubsetOf(projectAcc.GetCoins()) ||
    minimumFunding.IsAnyGT(projectAcc.GetCoins()) {
    // Project does NOT have enough funding
}
```

The `DenomsSubsetOf` check ensures that the `projectAcc` coins has all denoms that are in the minimum funding, meaning that the project at least has non-zero values for all coin denoms expected in the minimum. The second check then confirms that these values are all greater than the minimum (or that the minimum does not have any value greater than the project coins).