### PR TITLE
Add 'Alpha Bond' Flag

### DIFF
--- a/scripts/demo_bonds_augmented_alpha_1.sh
+++ b/scripts/demo_bonds_augmented_alpha_1.sh
@@ -84,14 +84,14 @@ ixocli tx did add-did-doc "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-pri
 echo "Ledgering DID 3/3..."
 ixocli tx did add-did-doc "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
-# d0 := 500.0   // initial raise (reserve)
-# p0 := 0.01    // initial price (reserve per token)
-# theta := 0.4  // initial allocation (percentage)
-# kappa := 3.0  // degrees of polynomial (i.e. x^2, x^4, x^6)
+# d0 := 1000000 // initial raise (reserve)
+# p0 := 1       // initial price (reserve per token)
+# theta := 0    // initial allocation (percentage)
+# kappa := 3    // degrees of polynomial (i.e. x^2, x^4, x^6)
 
-# R0 = 300              // initial reserve (1-theta)*d0
-# S0 = 50000            // initial supply
-# V0 = 416666666666.667 // invariant
+# R0 = 1000000        // initial reserve (1-theta)*d0
+# S0 = 1000000        // initial supply
+# V0 = 1000000000000  // invariant
 
 echo "Creating bond..."
 ixocli tx bonds create-bond \
@@ -99,18 +99,18 @@ ixocli tx bonds create-bond \
   --name="A B C" \
   --description="Description about A B C" \
   --function-type=augmented_function \
-  --function-parameters="d0:500.0,p0:0.01,theta:0.4,kappa:3.0" \
+  --function-parameters="d0:1000000,p0:1,theta:0,kappa:3.0" \
   --reserve-tokens=res \
   --tx-fee-percentage=0 \
   --exit-fee-percentage=0 \
   --fee-address="$FEE" \
-  --max-supply=1000000abc \
+  --max-supply=20000000abc \
   --order-quantity-limits="" \
   --sanity-rate="0" \
   --sanity-margin-percentage="0" \
-  --allow-sells \
+  --alpha-bond \
   --batch-blocks=1 \
-  --outcome-payment="100000" \
+  --outcome-payment="300000000" \
   --bond-did="$BOND_DID" \
   --creator-did="$MIGUEL_DID_FULL" \
   --controller-did="$FRANCESCO_DID" \
@@ -118,49 +118,49 @@ ixocli tx bonds create-bond \
 echo "Created bond..."
 ixocli q bonds bond "$BOND_DID"
 
-echo "Miguel buys 20000abc..."
-ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel buys 400000abc..."
+ixocli tx bonds buy 400000abc 500000res "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Miguel's account..."
 ixocli q auth account "$MIGUEL_ADDR"
 
-echo "Francesco buys 20000abc..."
-ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco buys 400000abc..."
+ixocli tx bonds buy 400000abc 500000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
 
-echo "Shaun cannot buy 10001abc..."
-ixocli tx bonds buy 10001abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun cannot buy 200001abc..."
+ixocli tx bonds buy 200001abc 500000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Shaun cannot sell anything..."
-ixocli tx bonds sell 10000abc "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun can buy 10000abc..."
-ixocli tx bonds buy 10000abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+ixocli tx bonds sell 20000abc "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun can buy 200000abc..."
+ixocli tx bonds buy 200000abc 500000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Shaun's account..."
 ixocli q auth account "$SHAUN_ADDR"
 
 echo "Bond state is now open..."  # since 50000 (S0) reached
 ixocli q bonds bond "$BOND_DID"
 
-echo "Current price is 0.018..."
+echo "Current price is 3..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.003->0.004..."
-NEW_ALPHA="0.004"
+echo "Changing alpha to 0.0033->0.0044..."
+NEW_ALPHA="0.0044"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now [still] 0.018..."
+echo "Current price is now approx 2.94..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.004->0.003..."
-NEW_ALPHA="0.003"
+echo "Changing alpha to 0.0044->0.0033..."
+NEW_ALPHA="0.0033"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now 0.012..."
+echo "Current price is now approx 1.98..."
 ixocli q bonds current-price "$BOND_DID"
 
 echo "Cannot change alpha to 0.0033->0.09..."
 NEW_ALPHA="0.09"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
-echo "Miguel sells 20000abc..."
-ixocli tx bonds sell 20000abc "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel sells 400000abc..."
+ixocli tx bonds sell 400000abc "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Miguel's account..."
 ixocli q auth account "$MIGUEL_ADDR"
 
@@ -173,8 +173,8 @@ ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FUL
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
 
-echo "Francesco updates the bond state to FAILED"
-ixocli tx bonds update-bond-state "FAILED" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+echo "Francesco updates the bond state to SETTLE"
+ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
 
 echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y

--- a/scripts/demo_bonds_augmented_alpha_2_failed.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_failed.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+wait() {
+  echo "Waiting for chain to start..."
+  while :; do
+    RET=$(ixocli status 2>&1)
+    if [[ ($RET == ERROR*) || ($RET == *'"latest_block_height": "0"'*) ]]; then
+      sleep 1
+    else
+      echo "A few more seconds..."
+      sleep 6
+      break
+    fi
+  done
+}
+
+tx() {
+  cmd=$1
+  shift
+  "$cmd" --broadcast-mode block "$@"
+}
+
+RET=$(ixocli status 2>&1)
+if [[ ($RET == ERROR*) || ($RET == *'"latest_block_height": "0"'*) ]]; then
+  wait
+fi
+
+PASSWORD="12345678"
+GAS_PRICES="0.025uixo"
+FEE=$(yes $PASSWORD | ixocli keys show fee -a)
+
+BOND_DID="did:ixo:U7GK8p8rVhJMKhBVRCJJ8c"
+#BOND_DID_FULL='{
+#  "did":"did:ixo:U7GK8p8rVhJMKhBVRCJJ8c",
+#  "verifyKey":"FmwNAfvV2xEqHwszrVJVBR3JgQ8AFCQEVzo1p6x4L8VW",
+#  "encryptionPublicKey":"domKpTpjrHQtKUnaFLjCuDLe2oHeS4b1sKt7yU9cq7m",
+#  "secret":{
+#    "seed":"933e454dbcfc1437f3afc10a0cd512cf0339787b6595819849f53707c268b053",
+#    "signKey":"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC",
+#    "encryptionPrivateKey":"Aun1EpjR1HQu1idBsPQ4u4C4dMwtbYPe1SdSC5bUerFC"
+#  }
+#}'
+
+MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"
+FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y"
+SHAUN_ADDR="ixo1d5u5ta7np7vefxa7ttpuy5aurg7q5regm0t2un"
+MIGUEL_DID_FULL='{
+  "did":"did:ixo:4XJLBfGtWSGKSz4BeRxdun",
+  "verifyKey":"2vMHhssdhrBCRFiq9vj7TxGYDybW4yYdrYh9JG56RaAt",
+  "encryptionPublicKey":"6GBp8qYgjE3ducksUa9Ar26ganhDFcmYfbZE9ezFx5xS",
+  "secret":{
+    "seed":"38734eeb53b5d69177da1fa9a093f10d218b3e0f81087226be6ce0cdce478180",
+    "signKey":"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh",
+    "encryptionPrivateKey":"4oMozrMR6BXRN93MDk6UYoqBVBLiPn9RnZhR3wQd6tBh"
+  }
+}'
+FRANCESCO_DID="did:ixo:UKzkhVSHc3qEFva5EY2XHt"
+FRANCESCO_DID_FULL='{
+  "did":"did:ixo:UKzkhVSHc3qEFva5EY2XHt",
+  "verifyKey":"Ftsqjc2pEvGLqBtgvVx69VXLe1dj2mFzoi4kqQNGo3Ej",
+  "encryptionPublicKey":"8YScf3mY4eeHoxDT9MRxiuGX5Fw7edWFnwHpgWYSn1si",
+  "secret":{
+    "seed":"94f3c48a9b19b4881e582ba80f5767cd3f3c5d7b7103cb9a50fa018f108d89de",
+    "signKey":"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM",
+    "encryptionPrivateKey":"B2Svs8GoQnUJHg8W2Ch7J53Goq36AaF6C6W4PD2MCPrM"
+  }
+}'
+SHAUN_DID_FULL='{
+  "did":"did:ixo:U4tSpzzv91HHqWW1YmFkHJ",
+  "verifyKey":"FkeDue5it82taeheMprdaPrctfK3DeVV9NnEPYDgwwRG",
+  "encryptionPublicKey":"DtdGbZB2nSQvwhs6QoN5Cd8JTxWgfVRAGVKfxj8LA15i",
+  "secret":{
+    "seed":"6ef0002659d260a0bbad194d1aa28650ccea6c6862f994dfdbd48648e1a05c5e",
+    "signKey":"8U474VrG2QiUFKfeNnS84CAsqHdmVRjEx4vQje122ycR",
+    "encryptionPrivateKey":"8U474VrG2QiUFKfeNnS84CAsqHdmVRjEx4vQje122ycR"
+  }
+}'
+
+# Ledger DIDs
+echo "Ledgering DID 1/3..."
+ixocli tx did add-did-doc "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Ledgering DID 2/3..."
+ixocli tx did add-did-doc "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Ledgering DID 3/3..."
+ixocli tx did add-did-doc "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+
+# d0 := 500.0   // initial raise (reserve)
+# p0 := 0.01    // initial price (reserve per token)
+# theta := 0.4  // initial allocation (percentage)
+# kappa := 3.0  // degrees of polynomial (i.e. x^2, x^4, x^6)
+
+# R0 = 300              // initial reserve (1-theta)*d0
+# S0 = 50000            // initial supply
+# V0 = 416666666666.667 // invariant
+
+echo "Creating bond..."
+ixocli tx bonds create-bond \
+  --token=abc \
+  --name="A B C" \
+  --description="Description about A B C" \
+  --function-type=augmented_function \
+  --function-parameters="d0:500.0,p0:0.01,theta:0.4,kappa:3.0" \
+  --reserve-tokens=res \
+  --tx-fee-percentage=0 \
+  --exit-fee-percentage=0 \
+  --fee-address="$FEE" \
+  --max-supply=1000000abc \
+  --order-quantity-limits="" \
+  --sanity-rate="0" \
+  --sanity-margin-percentage="0" \
+  --allow-sells \
+  --alpha-bond \
+  --batch-blocks=1 \
+  --outcome-payment="100000" \
+  --bond-did="$BOND_DID" \
+  --creator-did="$MIGUEL_DID_FULL" \
+  --controller-did="$FRANCESCO_DID" \
+  --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Created bond..."
+ixocli q bonds bond "$BOND_DID"
+
+echo "Miguel buys 20000abc..."
+ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel's account..."
+ixocli q auth account "$MIGUEL_ADDR"
+
+echo "Francesco buys 20000abc..."
+ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco's account..."
+ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Shaun cannot buy 10001abc..."
+ixocli tx bonds buy 10001abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun cannot sell anything..."
+ixocli tx bonds sell 10000abc "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun can buy 10000abc..."
+ixocli tx bonds buy 10000abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun's account..."
+ixocli q auth account "$SHAUN_ADDR"
+
+echo "Bond state is now open..."  # since 50000 (S0) reached
+ixocli q bonds bond "$BOND_DID"
+
+echo "Current price is 0.018..."
+ixocli q bonds current-price "$BOND_DID"
+
+echo "Changing alpha to 0.003->0.004..."
+NEW_ALPHA="0.004"
+ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Current price is now [still] 0.018..."
+ixocli q bonds current-price "$BOND_DID"
+
+echo "Changing alpha to 0.004->0.003..."
+NEW_ALPHA="0.003"
+ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Current price is now 0.012..."
+ixocli q bonds current-price "$BOND_DID"
+
+echo "Cannot change alpha to 0.0033->0.09..."
+NEW_ALPHA="0.09"
+ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+
+echo "Miguel sells 20000abc..."
+ixocli tx bonds sell 20000abc "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel's account..."
+ixocli q auth account "$MIGUEL_ADDR"
+
+echo "Francesco makes outcome payment of 50000000 [1]..."
+ixocli tx bonds make-outcome-payment "$BOND_DID" "50000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco makes outcome payment of 100000000 [2]..."
+ixocli tx bonds make-outcome-payment "$BOND_DID" "100000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco makes outcome payment of 150000000 [3]..."
+ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco's account..."
+ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Francesco updates the bond state to SETTLE"
+ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+
+echo "Francesco withdraws share..."
+ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco's account..."
+ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Shaun withdraws share..."
+ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun's account..."
+ixocli q auth account "$SHAUN_ADDR"

--- a/scripts/demo_bonds_augmented_alpha_2_success.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_success.sh
@@ -84,14 +84,14 @@ ixocli tx did add-did-doc "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-pri
 echo "Ledgering DID 3/3..."
 ixocli tx did add-did-doc "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
-# d0 := 1000000 // initial raise (reserve)
-# p0 := 1       // initial price (reserve per token)
-# theta := 0    // initial allocation (percentage)
-# kappa := 3    // degrees of polynomial (i.e. x^2, x^4, x^6)
+# d0 := 500.0   // initial raise (reserve)
+# p0 := 0.01    // initial price (reserve per token)
+# theta := 0.4  // initial allocation (percentage)
+# kappa := 3.0  // degrees of polynomial (i.e. x^2, x^4, x^6)
 
-# R0 = 1000000        // initial reserve (1-theta)*d0
-# S0 = 1000000        // initial supply
-# V0 = 1000000000000  // invariant
+# R0 = 300              // initial reserve (1-theta)*d0
+# S0 = 50000            // initial supply
+# V0 = 416666666666.667 // invariant
 
 echo "Creating bond..."
 ixocli tx bonds create-bond \
@@ -99,17 +99,19 @@ ixocli tx bonds create-bond \
   --name="A B C" \
   --description="Description about A B C" \
   --function-type=augmented_function \
-  --function-parameters="d0:1000000,p0:1,theta:0,kappa:3.0" \
+  --function-parameters="d0:500.0,p0:0.01,theta:0.4,kappa:3.0" \
   --reserve-tokens=res \
   --tx-fee-percentage=0 \
   --exit-fee-percentage=0 \
   --fee-address="$FEE" \
-  --max-supply=20000000abc \
+  --max-supply=1000000abc \
   --order-quantity-limits="" \
   --sanity-rate="0" \
   --sanity-margin-percentage="0" \
+  --allow-sells \
+  --alpha-bond \
   --batch-blocks=1 \
-  --outcome-payment="300000000" \
+  --outcome-payment="100000" \
   --bond-did="$BOND_DID" \
   --creator-did="$MIGUEL_DID_FULL" \
   --controller-did="$FRANCESCO_DID" \
@@ -117,70 +119,25 @@ ixocli tx bonds create-bond \
 echo "Created bond..."
 ixocli q bonds bond "$BOND_DID"
 
-echo "Miguel buys 400000abc..."
-ixocli tx bonds buy 400000abc 500000res "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel buys 20000abc..."
+ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Miguel's account..."
 ixocli q auth account "$MIGUEL_ADDR"
 
-echo "Francesco buys 400000abc..."
-ixocli tx bonds buy 400000abc 500000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco buys 20000abc..."
+ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
 
-echo "Shaun cannot buy 200001abc..."
-ixocli tx bonds buy 200001abc 500000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun cannot sell anything..."
-ixocli tx bonds sell 20000abc "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun can buy 200000abc..."
-ixocli tx bonds buy 200000abc 500000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun's account..."
-ixocli q auth account "$SHAUN_ADDR"
+echo "Francesco updates the bond state to FAILED"
+ixocli tx bonds update-bond-state "FAILED" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
 
-echo "Bond state is now open..."  # since 50000 (S0) reached
-ixocli q bonds bond "$BOND_DID"
-
-echo "Current price is 3..."
-ixocli q bonds current-price "$BOND_DID"
-
-echo "Changing alpha to 0.0033->0.0044..."
-NEW_ALPHA="0.0044"
-ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 2.94..."
-ixocli q bonds current-price "$BOND_DID"
-
-echo "Changing alpha to 0.0044->0.0033..."
-NEW_ALPHA="0.0033"
-ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.98..."
-ixocli q bonds current-price "$BOND_DID"
-
-echo "Cannot change alpha to 0.0033->0.09..."
-NEW_ALPHA="0.09"
-ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-
-echo "Miguel sells 400000abc..."
-ixocli tx bonds sell 400000abc "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel withdraws share..."
+ixocli tx bonds withdraw-share "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Miguel's account..."
 ixocli q auth account "$MIGUEL_ADDR"
-
-echo "Francesco makes outcome payment of 50000000 [1]..."
-ixocli tx bonds make-outcome-payment "$BOND_DID" "50000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Francesco makes outcome payment of 100000000 [2]..."
-ixocli tx bonds make-outcome-payment "$BOND_DID" "100000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Francesco makes outcome payment of 150000000 [3]..."
-ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Francesco's account..."
-ixocli q auth account "$FRANCESCO_ADDR"
-
-echo "Francesco updates the bond state to SETTLE"
-ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
 
 echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
-
-echo "Shaun withdraws share..."
-ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun's account..."
-ixocli q auth account "$SHAUN_ADDR"

--- a/scripts/run_with_all_data.sh
+++ b/scripts/run_with_all_data.sh
@@ -23,17 +23,17 @@ yes $PASSWORD | ixocli keys add fee4
 yes $PASSWORD | ixocli keys add fee5
 
 # Note: important to add 'miguel' as a genesis-account since this is the chain's validator
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 100000000000uixo,100000000000res,100000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 1000000000000uixo,1000000000000res,1000000000000rez
 
 # Add pubkey-based genesis accounts
 MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"    # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun's pubkey
 FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y" # address from did:ixo:UKzkhVSHc3qEFva5EY2XHt's pubkey
 SHAUN_ADDR="ixo1d5u5ta7np7vefxa7ttpuy5aurg7q5regm0t2un"     # address from did:ixo:U4tSpzzv91HHqWW1YmFkHJ's pubkey
-yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 100000000000uixo,100000000000res,100000000000rez
+yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
 
 # Add genesis oracles
 MIGUEL_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"

--- a/scripts/run_with_all_data_and_genesis_file.sh
+++ b/scripts/run_with_all_data_and_genesis_file.sh
@@ -29,17 +29,17 @@ yes $PASSWORD | ixocli keys add fee4
 yes $PASSWORD | ixocli keys add fee5
 
 # Note: important to add 'miguel' as a genesis-account since this is the chain's validator
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 100000000000uixo,100000000000res,100000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 1000000000000uixo,1000000000000res,1000000000000rez
 
 # Add pubkey-based genesis accounts
 MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"    # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun's pubkey
 FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y" # address from did:ixo:UKzkhVSHc3qEFva5EY2XHt's pubkey
 SHAUN_ADDR="ixo1d5u5ta7np7vefxa7ttpuy5aurg7q5regm0t2un"     # address from did:ixo:U4tSpzzv91HHqWW1YmFkHJ's pubkey
-yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 100000000000uixo,100000000000res,100000000000rez
+yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
 
 # Add genesis oracles
 MIGUEL_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"

--- a/scripts/run_with_all_data_dev.sh
+++ b/scripts/run_with_all_data_dev.sh
@@ -23,17 +23,17 @@ yes $PASSWORD | ixocli keys add fee4
 yes $PASSWORD | ixocli keys add fee5
 
 # Note: important to add 'miguel' as a genesis-account since this is the chain's validator
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 100000000000uixo,100000000000res,100000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show miguel -a)" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show francesco -a)" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$(ixocli keys show shaun -a)" 1000000000000uixo,1000000000000res,1000000000000rez
 
 # Add pubkey-based genesis accounts
 MIGUEL_ADDR="ixo107pmtx9wyndup8f9lgj6d7dnfq5kuf3sapg0vx"    # address from did:ixo:4XJLBfGtWSGKSz4BeRxdun's pubkey
 FRANCESCO_ADDR="ixo1cpa6w2wnqyxpxm4rryfjwjnx75kn4xt372dp3y" # address from did:ixo:UKzkhVSHc3qEFva5EY2XHt's pubkey
 SHAUN_ADDR="ixo1d5u5ta7np7vefxa7ttpuy5aurg7q5regm0t2un"     # address from did:ixo:U4tSpzzv91HHqWW1YmFkHJ's pubkey
-yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 100000000000uixo,100000000000res,100000000000rez
-yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 100000000000uixo,100000000000res,100000000000rez
+yes $PASSWORD | ixod add-genesis-account "$MIGUEL_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$FRANCESCO_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
+yes $PASSWORD | ixod add-genesis-account "$SHAUN_ADDR" 1000000000000uixo,1000000000000res,1000000000000rez
 
 # Add genesis oracles
 MIGUEL_DID="did:ixo:4XJLBfGtWSGKSz4BeRxdun"

--- a/x/bonds/client/cli/flags.go
+++ b/x/bonds/client/cli/flags.go
@@ -20,6 +20,7 @@ const (
 	FlagSanityRate             = "sanity-rate"
 	FlagSanityMarginPercentage = "sanity-margin-percentage"
 	FlagAllowSells             = "allow-sells"
+	FlagAlphaBond              = "alpha-bond"
 	FlagBatchBlocks            = "batch-blocks"
 	FlagOutcomePayment         = "outcome-payment"
 	FlagBondDid                = "bond-did"
@@ -50,7 +51,8 @@ func init() {
 	fsBondCreate.String(FlagOrderQuantityLimits, "", "The max number of tokens bought/sold/swapped per order")
 	fsBondCreate.String(FlagSanityRate, "", "For swappers, this is the typical t1 per t2 rate")
 	fsBondCreate.String(FlagSanityMarginPercentage, "", "For swappers, this is the acceptable deviation from the sanity rate")
-	fsBondCreate.Bool(FlagAllowSells, false, "Whether or not sells will be allowed")
+	fsBondCreate.Bool(FlagAllowSells, false, "Whether or not sells will be allowed (including the flag enables sells)")
+	fsBondCreate.Bool(FlagAlphaBond, false, "Whether or not augmented bonding curve is an alpha bond (including the flag enables alpha)")
 	fsBondCreate.String(FlagBatchBlocks, "", "The duration in terms of blocks of each orders batch")
 	fsBondCreate.String(FlagOutcomePayment, "", "The payment that would be required to transition the bond to settlement")
 	fsBondCreate.String(FlagBondDid, "", "Bond's DID")

--- a/x/bonds/client/cli/tx.go
+++ b/x/bonds/client/cli/tx.go
@@ -60,6 +60,7 @@ func GetCmdCreateBond(cdc *codec.Codec) *cobra.Command {
 			_sanityRate := viper.GetString(FlagSanityRate)
 			_sanityMarginPercentage := viper.GetString(FlagSanityMarginPercentage)
 			_allowSells := viper.GetBool(FlagAllowSells)
+			_alphaBond := viper.GetBool(FlagAlphaBond)
 			_batchBlocks := viper.GetString(FlagBatchBlocks)
 			_outcomePayment := viper.GetString(FlagOutcomePayment)
 			_bondDid := viper.GetString(FlagBondDid)
@@ -148,7 +149,7 @@ func GetCmdCreateBond(cdc *codec.Codec) *cobra.Command {
 				creatorDid.Did, _controllerDid, _functionType, functionParams,
 				reserveTokens, txFeePercentage, exitFeePercentage, feeAddress,
 				maxSupply, orderQuantityLimits, sanityRate, sanityMarginPercentage,
-				_allowSells, batchBlocks, outcomePayment, _bondDid)
+				_allowSells, _alphaBond, batchBlocks, outcomePayment, _bondDid)
 
 			return ixo.GenerateOrBroadcastMsgs(cliCtx, msg, creatorDid)
 		},

--- a/x/bonds/client/rest/tx.go
+++ b/x/bonds/client/rest/tx.go
@@ -41,6 +41,7 @@ type createBondReq struct {
 	SanityRate             string       `json:"sanity_rate" yaml:"sanity_rate"`
 	SanityMarginPercentage string       `json:"sanity_margin_percentage" yaml:"sanity_margin_percentage"`
 	AllowSells             string       `json:"allow_sells" yaml:"allow_sells"`
+	AlphaBond              string       `json:"alpha_bond" yaml:"alpha_bond"`
 	BatchBlocks            string       `json:"batch_blocks" yaml:"batch_blocks"`
 	OutcomePayment         string       `json:"outcome_payment" yaml:"outcome_payment"`
 	BondDid                string       `json:"bond_did" yaml:"bond_did"`
@@ -134,6 +135,19 @@ func createBondRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		// Parse alphaBond
+		var alphaBond bool
+		alphaBondStrLower := strings.ToLower(req.AlphaBond)
+		if alphaBondStrLower == "true" {
+			alphaBond = true
+		} else if alphaBondStrLower == "false" {
+			alphaBond = false
+		} else {
+			err := sdkerrors.Wrap(types.ErrArgumentMissingOrNonBoolean, "alpha_bond")
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
 		// Parse batch blocks
 		batchBlocks, err := sdk.ParseUint(req.BatchBlocks)
 		if err != nil {
@@ -160,7 +174,7 @@ func createBondRequestHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			req.CreatorDid, req.ControllerDid, req.FunctionType, functionParams, reserveTokens,
 			txFeePercentageDec, exitFeePercentageDec, feeAddress, maxSupply,
 			orderQuantityLimits, sanityRate, sanityMarginPercentage,
-			allowSells, batchBlocks, outcomePayment, req.BondDid)
+			allowSells, alphaBond, batchBlocks, outcomePayment, req.BondDid)
 		if err := msg.ValidateBasic(); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/bonds/internal/types/bonds.go
+++ b/x/bonds/internal/types/bonds.go
@@ -237,6 +237,7 @@ type Bond struct {
 	CurrentReserve               sdk.Coins      `json:"current_reserve" yaml:"current_reserve"`
 	CurrentOutcomePaymentReserve sdk.Coins      `json:"current_outcome_payment_reserve" yaml:"current_outcome_payment_reserve"`
 	AllowSells                   bool           `json:"allow_sells" yaml:"allow_sells"`
+	AlphaBond                    bool           `json:"alpha_bond" yaml:"alpha_bond"`
 	BatchBlocks                  sdk.Uint       `json:"batch_blocks" yaml:"batch_blocks"`
 	OutcomePayment               sdk.Int        `json:"outcome_payment" yaml:"outcome_payment"`
 	State                        BondState      `json:"state" yaml:"state"`
@@ -247,7 +248,7 @@ func NewBond(token, name, description string, creatorDid, controllerDid did.Did,
 	functionType string, functionParameters FunctionParams, reserveTokens []string,
 	txFeePercentage, exitFeePercentage sdk.Dec, feeAddress sdk.AccAddress,
 	maxSupply sdk.Coin, orderQuantityLimits sdk.Coins, sanityRate,
-	sanityMarginPercentage sdk.Dec, allowSells bool, batchBlocks sdk.Uint,
+	sanityMarginPercentage sdk.Dec, allowSells, alphaBond bool, batchBlocks sdk.Uint,
 	outcomePayment sdk.Int, state BondState, bondDid did.Did) Bond {
 
 	// Ensure tokens and coins are sorted
@@ -274,6 +275,7 @@ func NewBond(token, name, description string, creatorDid, controllerDid did.Did,
 		CurrentReserve:               nil,
 		CurrentOutcomePaymentReserve: nil,
 		AllowSells:                   allowSells,
+		AlphaBond:                    alphaBond,
 		BatchBlocks:                  batchBlocks,
 		OutcomePayment:               outcomePayment,
 		State:                        state,

--- a/x/bonds/internal/types/events.go
+++ b/x/bonds/internal/types/events.go
@@ -33,6 +33,7 @@ const (
 	AttributeKeySanityRate             = "sanity_rate"
 	AttributeKeySanityMarginPercentage = "sanity_margin_percentage"
 	AttributeKeyAllowSells             = "allow_sells"
+	AttributeKeyAlphaBond              = "alpha_bond"
 	AttributeKeyBatchBlocks            = "batch_blocks"
 	AttributeKeyOutcomePayment         = "outcome_payment"
 	AttributeKeyState                  = "state"

--- a/x/bonds/spec/01_concepts.md
+++ b/x/bonds/spec/01_concepts.md
@@ -58,6 +58,7 @@ type Bond struct {
 	CurrentSupply          sdk.Coin
 	CurrentReserve         sdk.Coins
 	AllowSells             bool
+	AlphaBond              bool
 	Signers                []sdk.AccAddress
 	BatchBlocks            sdk.Uint
 	OutcomePayment         sdk.Coins

--- a/x/bonds/spec/03_messages.md
+++ b/x/bonds/spec/03_messages.md
@@ -25,6 +25,7 @@ Bonds can be created by any address using `MsgCreateBond`.
 | SanityRate             | `sdk.Dec`        | For a swapper, restricts conversion rate (`r1/r2`) to `sanity rate ± sanity margin percentage`. `0` for no sanity checks.
 | SanityMarginPercentage | `sdk.Dec`        | Used as described above. `0` for no sanity checks
 | AllowSells             | `bool`           | Whether or not selling is allowed
+| AlphaBond              | `bool`           | Whether or not bond is an alpha bond
 | BatchBlocks            | `sdk.Uint`       | The lifespan of each orders batch in blocks
 | OutcomePayment         | `sdk.Int`        | The approximate total payment required to be made in order to transition a bond from OPEN to SETTLE
 
@@ -47,6 +48,7 @@ type MsgCreateBond struct {
 	SanityRate             sdk.Dec
 	SanityMarginPercentage sdk.Dec
 	AllowSells             bool
+    AlphaBond              bool
 	BatchBlocks            sdk.Uint
 	OutcomePayment         sdk.Int
 }

--- a/x/bonds/spec/03_messages.md
+++ b/x/bonds/spec/03_messages.md
@@ -48,7 +48,7 @@ type MsgCreateBond struct {
 	SanityRate             sdk.Dec
 	SanityMarginPercentage sdk.Dec
 	AllowSells             bool
-    AlphaBond              bool
+	AlphaBond              bool
 	BatchBlocks            sdk.Uint
 	OutcomePayment         sdk.Int
 }

--- a/x/bonds/spec/05_events.md
+++ b/x/bonds/spec/05_events.md
@@ -41,6 +41,7 @@ The bonds module emits the following events:
 | create_bond | sanity_rate              | {sanityRate}             |
 | create_bond | sanity_margin_percentage | {sanityMarginPercentage} |
 | create_bond | allow_sells              | {allowSells}             |
+| create_bond | alpha_bond               | {alphaBond}              |
 | create_bond | signers [2]              | {signers}                |
 | create_bond | batch_blocks             | {batchBlocks}            |
 | create_bond | state                    | {state}                  |


### PR DESCRIPTION
Currently all Augmented Bonding Curves get assigned an alpha value at creation, even if the intention is not for them to be Alpha Bonds. This PR adds an 'alpha-bond' flag to the bond creation message and the bond type so that Alpha Bonds related functionality is excluded or skipped if a bond is not an alpha bond. Similarly, Alpha Bond related functionality will be disabled if the bond is not an Alpha Bond.