### PR TITLE
Introduce Public Alpha

### DIFF
--- a/scripts/demo_bonds_augmented.sh
+++ b/scripts/demo_bonds_augmented.sh
@@ -149,7 +149,7 @@ echo "Francesco makes outcome payment of 60000000000..."
 ixocli tx bonds make-outcome-payment "$BOND_DID" "60000000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
-echo "Bond outcome payment reserve is now 300000000..."
+echo "Bond outcome payment reserve is now 60000000000..."
 ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco updates the bond state to SETTLE"

--- a/scripts/demo_bonds_augmented.sh
+++ b/scripts/demo_bonds_augmented.sh
@@ -149,9 +149,13 @@ echo "Francesco makes outcome payment of 60000000000..."
 ixocli tx bonds make-outcome-payment "$BOND_DID" "60000000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+echo "Bond outcome payment reserve is now 300000000..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco updates the bond state to SETTLE"
 ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+echo "Bond outcome payment reserve is now empty (moved to main reserve)..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Miguel withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
@@ -162,3 +166,6 @@ echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Bond reserve is now empty and supply is 0..."
+ixocli q bonds bond "$BOND_DID"

--- a/scripts/demo_bonds_augmented_alpha_1_sells_disabled.sh
+++ b/scripts/demo_bonds_augmented_alpha_1_sells_disabled.sh
@@ -143,20 +143,20 @@ ixocli q bonds bond "$BOND_DID"
 echo "Current price is 3..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.0033->0.0044..."
-NEW_ALPHA="0.0044"
+echo "Changing public alpha 0.5->0.505..."
+NEW_ALPHA="0.505"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 2.94..."
+echo "Current price is now approx 1.65..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.0044->0.0033..."
-NEW_ALPHA="0.0033"
+echo "Changing public alpha 0.505->0.5..."
+NEW_ALPHA="0.5"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.98..."
+echo "Current price is now approx 1.66..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Cannot change alpha to 0.0033->0.09..."
-NEW_ALPHA="0.09"
+echo "Cannot change public alpha 0.5->0.6..."
+NEW_ALPHA="0.6"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
 echo "Miguel cannot sell because sells are disabled..."

--- a/scripts/demo_bonds_augmented_alpha_1_sells_disabled.sh
+++ b/scripts/demo_bonds_augmented_alpha_1_sells_disabled.sh
@@ -137,25 +137,25 @@ ixocli tx bonds buy 200000abc 500000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcas
 echo "Shaun's account..."
 ixocli q auth account "$SHAUN_ADDR"
 
-echo "Bond state is now open..."  # since 50000 (S0) reached
+echo "Bond state is now open..."  # since 1000000 (S0) reached
 ixocli q bonds bond "$BOND_DID"
 
 echo "Current price is 3..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing public alpha 0.5->0.505..."
-NEW_ALPHA="0.505"
+echo "Changing public alpha 0.5->0.51..."
+NEW_ALPHA="0.51"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.65..."
+echo "Current price is now approx 1.85..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing public alpha 0.505->0.5..."
-NEW_ALPHA="0.5"
+echo "Changing public alpha 0.51->0.4..."
+NEW_ALPHA="0.4"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.66..."
+echo "Current price is now approx 1.86..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Cannot change public alpha 0.5->0.6..."
+echo "Cannot change public alpha 0.4->0.6..."
 NEW_ALPHA="0.6"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
@@ -170,9 +170,13 @@ echo "Francesco makes outcome payment of 150000000 [3]..."
 ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+echo "Bond outcome payment reserve is now 300000000..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco updates the bond state to SETTLE"
 ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+echo "Bond outcome payment reserve is now empty (moved to main reserve)..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Miguel withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
@@ -188,3 +192,6 @@ echo "Shaun withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Shaun's account..."
 ixocli q auth account "$SHAUN_ADDR"
+
+echo "Bond reserve is now empty and supply is 0..."
+ixocli q bonds bond "$BOND_DID"

--- a/scripts/demo_bonds_augmented_alpha_1_sells_enabled.sh
+++ b/scripts/demo_bonds_augmented_alpha_1_sells_enabled.sh
@@ -144,20 +144,20 @@ ixocli q bonds bond "$BOND_DID"
 echo "Current price is 3..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.0033->0.0044..."
-NEW_ALPHA="0.0044"
+echo "Changing public alpha 0.5->0.505..."
+NEW_ALPHA="0.505"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 2.94..."
+echo "Current price is now approx 1.65..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.0044->0.0033..."
-NEW_ALPHA="0.0033"
+echo "Changing public alpha 0.505->0.5..."
+NEW_ALPHA="0.5"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.98..."
+echo "Current price is now approx 1.66..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Cannot change alpha to 0.0033->0.09..."
-NEW_ALPHA="0.09"
+echo "Cannot change public alpha 0.5->0.6..."
+NEW_ALPHA="0.6"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
 echo "Miguel sells 400000abc..."

--- a/scripts/demo_bonds_augmented_alpha_1_sells_enabled.sh
+++ b/scripts/demo_bonds_augmented_alpha_1_sells_enabled.sh
@@ -138,25 +138,25 @@ ixocli tx bonds buy 200000abc 500000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcas
 echo "Shaun's account..."
 ixocli q auth account "$SHAUN_ADDR"
 
-echo "Bond state is now open..."  # since 50000 (S0) reached
+echo "Bond state is now open..."  # since 1000000 (S0) reached
 ixocli q bonds bond "$BOND_DID"
 
 echo "Current price is 3..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing public alpha 0.5->0.505..."
-NEW_ALPHA="0.505"
+echo "Changing public alpha 0.5->0.51..."
+NEW_ALPHA="0.51"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.65..."
+echo "Current price is now approx 1.85..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing public alpha 0.505->0.5..."
-NEW_ALPHA="0.5"
+echo "Changing public alpha 0.51->0.4..."
+NEW_ALPHA="0.4"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 1.66..."
+echo "Current price is now approx 1.86..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Cannot change public alpha 0.5->0.6..."
+echo "Cannot change public alpha 0.4->0.6..."
 NEW_ALPHA="0.6"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
@@ -173,9 +173,13 @@ echo "Francesco makes outcome payment of 150000000 [3]..."
 ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+echo "Bond outcome payment reserve is now 300000000..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco updates the bond state to SETTLE"
 ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+echo "Bond outcome payment reserve is now empty (moved to main reserve)..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
@@ -186,3 +190,6 @@ echo "Shaun withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Shaun's account..."
 ixocli q auth account "$SHAUN_ADDR"
+
+echo "Bond reserve is now empty and supply is 0..."
+ixocli q bonds bond "$BOND_DID"

--- a/scripts/demo_bonds_augmented_alpha_2_failed.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_failed.sh
@@ -129,60 +129,15 @@ ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broad
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
 
-echo "Shaun cannot buy 10001abc..."
-ixocli tx bonds buy 10001abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun cannot sell anything..."
-ixocli tx bonds sell 10000abc "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun can buy 10000abc..."
-ixocli tx bonds buy 10000abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun's account..."
-ixocli q auth account "$SHAUN_ADDR"
+echo "Francesco updates the bond state to FAILED"
+ixocli tx bonds update-bond-state "FAILED" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
 
-echo "Bond state is now open..."  # since 50000 (S0) reached
-ixocli q bonds bond "$BOND_DID"
-
-echo "Current price is 0.018..."
-ixocli q bonds current-price "$BOND_DID"
-
-echo "Changing public alpha 0.5->0.51..."
-NEW_ALPHA="0.51"
-ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx 0.011..."
-ixocli q bonds current-price "$BOND_DID"
-
-echo "Changing public alpha 0.51->0.5..."
-NEW_ALPHA="0.5"
-ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx [still] 0.011..."
-ixocli q bonds current-price "$BOND_DID"
-
-echo "Cannot change public alpha 0.5->0.6..."
-NEW_ALPHA="0.6"
-ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-
-echo "Miguel sells 20000abc..."
-ixocli tx bonds sell 20000abc "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Miguel withdraws share..."
+ixocli tx bonds withdraw-share "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Miguel's account..."
 ixocli q auth account "$MIGUEL_ADDR"
-
-echo "Francesco makes outcome payment of 50000000 [1]..."
-ixocli tx bonds make-outcome-payment "$BOND_DID" "50000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Francesco makes outcome payment of 100000000 [2]..."
-ixocli tx bonds make-outcome-payment "$BOND_DID" "100000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Francesco makes outcome payment of 150000000 [3]..."
-ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Francesco's account..."
-ixocli q auth account "$FRANCESCO_ADDR"
-
-echo "Francesco updates the bond state to SETTLE"
-ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
 
 echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
-
-echo "Shaun withdraws share..."
-ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Shaun's account..."
-ixocli q auth account "$SHAUN_ADDR"

--- a/scripts/demo_bonds_augmented_alpha_2_failed.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_failed.sh
@@ -144,20 +144,20 @@ ixocli q bonds bond "$BOND_DID"
 echo "Current price is 0.018..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.003->0.004..."
-NEW_ALPHA="0.004"
+echo "Changing public alpha 0.5->0.51..."
+NEW_ALPHA="0.51"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now [still] 0.018..."
+echo "Current price is now approx 0.011..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing alpha to 0.004->0.003..."
-NEW_ALPHA="0.003"
+echo "Changing public alpha 0.51->0.5..."
+NEW_ALPHA="0.5"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now 0.012..."
+echo "Current price is now approx [still] 0.011..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Cannot change alpha to 0.0033->0.09..."
-NEW_ALPHA="0.09"
+echo "Cannot change public alpha 0.5->0.6..."
+NEW_ALPHA="0.6"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 
 echo "Miguel sells 20000abc..."

--- a/scripts/demo_bonds_augmented_alpha_2_failed.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_failed.sh
@@ -141,3 +141,6 @@ echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Bond reserve is now empty and supply is 0..."
+ixocli q bonds bond "$BOND_DID"

--- a/scripts/demo_bonds_augmented_alpha_2_success.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_success.sh
@@ -150,10 +150,10 @@ ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --
 echo "Current price is now approx 0.011..."
 ixocli q bonds current-price "$BOND_DID"
 
-echo "Changing public alpha 0.51->0.5..."
-NEW_ALPHA="0.5"
+echo "Changing public alpha 0.51->0.4..."
+NEW_ALPHA="0.4"
 ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
-echo "Current price is now approx [still] 0.011..."
+echo "Current price is still approx 0.011..."
 ixocli q bonds current-price "$BOND_DID"
 
 echo "Cannot change public alpha 0.5->0.6..."
@@ -173,9 +173,13 @@ echo "Francesco makes outcome payment of 150000000 [3]..."
 ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+echo "Bond outcome payment reserve is now 300000000..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco updates the bond state to SETTLE"
 ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+echo "Bond outcome payment reserve is now empty (moved to main reserve)..."
+ixocli q bonds bond "$BOND_DID"
 
 echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
@@ -186,3 +190,6 @@ echo "Shaun withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Shaun's account..."
 ixocli q auth account "$SHAUN_ADDR"
+
+echo "Bond reserve is now empty and supply is 0..."
+ixocli q bonds bond "$BOND_DID"

--- a/scripts/demo_bonds_augmented_alpha_2_success.sh
+++ b/scripts/demo_bonds_augmented_alpha_2_success.sh
@@ -129,15 +129,60 @@ ixocli tx bonds buy 20000abc 100000res "$BOND_DID" "$FRANCESCO_DID_FULL" --broad
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
 
-echo "Francesco updates the bond state to FAILED"
-ixocli tx bonds update-bond-state "FAILED" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
+echo "Shaun cannot buy 10001abc..."
+ixocli tx bonds buy 10001abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun cannot sell anything..."
+ixocli tx bonds sell 10000abc "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun can buy 10000abc..."
+ixocli tx bonds buy 10000abc 100000res "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun's account..."
+ixocli q auth account "$SHAUN_ADDR"
 
-echo "Miguel withdraws share..."
-ixocli tx bonds withdraw-share "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Bond state is now open..."  # since 50000 (S0) reached
+ixocli q bonds bond "$BOND_DID"
+
+echo "Current price is 0.018..."
+ixocli q bonds current-price "$BOND_DID"
+
+echo "Changing public alpha 0.5->0.51..."
+NEW_ALPHA="0.51"
+ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Current price is now approx 0.011..."
+ixocli q bonds current-price "$BOND_DID"
+
+echo "Changing public alpha 0.51->0.5..."
+NEW_ALPHA="0.5"
+ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Current price is now approx [still] 0.011..."
+ixocli q bonds current-price "$BOND_DID"
+
+echo "Cannot change public alpha 0.5->0.6..."
+NEW_ALPHA="0.6"
+ixocli tx bonds set-next-alpha "$NEW_ALPHA" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+
+echo "Miguel sells 20000abc..."
+ixocli tx bonds sell 20000abc "$BOND_DID" "$MIGUEL_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Miguel's account..."
 ixocli q auth account "$MIGUEL_ADDR"
+
+echo "Francesco makes outcome payment of 50000000 [1]..."
+ixocli tx bonds make-outcome-payment "$BOND_DID" "50000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco makes outcome payment of 100000000 [2]..."
+ixocli tx bonds make-outcome-payment "$BOND_DID" "100000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco makes outcome payment of 150000000 [3]..."
+ixocli tx bonds make-outcome-payment "$BOND_DID" "150000000" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Francesco's account..."
+ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Francesco updates the bond state to SETTLE"
+ixocli tx bonds update-bond-state "SETTLE" "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode=block --fees=5000uixo -y
 
 echo "Francesco withdraws share..."
 ixocli tx bonds withdraw-share "$BOND_DID" "$FRANCESCO_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
 echo "Francesco's account..."
 ixocli q auth account "$FRANCESCO_ADDR"
+
+echo "Shaun withdraws share..."
+ixocli tx bonds withdraw-share "$BOND_DID" "$SHAUN_DID_FULL" --broadcast-mode block --gas-prices="$GAS_PRICES" -y
+echo "Shaun's account..."
+ixocli q auth account "$SHAUN_ADDR"

--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -151,8 +151,8 @@ func handleMsgCreateBond(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgCre
 			})
 
 		if msg.AlphaBond {
-			// S1 * reserve / (S1 * reserve - S0 * reserve + S0 * C) with S0=S1=1
-			alpha := R0.QuoInt(msg.OutcomePayment)
+			alpha := types.Alpha(sdk.OneInt(), sdk.OneInt(),
+				R0.TruncateInt(), msg.OutcomePayment)
 
 			I0 := types.InvariantI(msg.OutcomePayment, alpha, sdk.ZeroInt())
 

--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -368,18 +368,18 @@ func handleMsgSetNextAlpha(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgS
 		newSystemAlpha = temp1.Mul(temp2)
 	}
 
-	// Check 1 (newSystemAlpha != systemAlpha)
-	if newSystemAlpha.Equal(paramsMap["systemAlpha"]) {
+	// Check 1 (newSystemAlpha != prevSystemAlpha)
+	if newSystemAlpha.Equal(prevSystemAlpha) {
 		return nil, sdkerrors.Wrap(types.ErrInvalidAlpha,
 			"resultant system alpha based on public alpha is unchanged")
 	}
-	// Check 2 (I > C * systemAlpha)
+	// Check 2 (I > C * newSystemAlpha)
 	if paramsMap["I0"].LTE(newSystemAlpha.MulInt(C)) {
 		return nil, sdkerrors.Wrap(types.ErrInvalidAlpha,
 			"cannot change alpha to that value due to violated restriction [1]")
 	}
-	// Check 3 (R / C > newSystemAlpha - systemAlpha)
-	if R.QuoInt(C).LTE(newSystemAlpha.Sub(paramsMap["systemAlpha"])) {
+	// Check 3 (R / C > newSystemAlpha - prevSystemAlpha)
+	if R.QuoInt(C).LTE(newSystemAlpha.Sub(prevSystemAlpha)) {
 		return nil, sdkerrors.Wrap(types.ErrInvalidAlpha,
 			"cannot change alpha to that value due to violated restriction [2]")
 	}

--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -74,6 +74,7 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) []abci.ValidatorUpdate {
 			args := bond.FunctionParameters.AsMap()
 			if bond.CurrentSupply.Amount.ToDec().GTE(args["S0"]) {
 				keeper.SetBondState(ctx, bond.BondDid, types.OpenState)
+				bond = keeper.MustGetBond(ctx, bond.BondDid) // get updated bond
 			}
 		}
 

--- a/x/bonds/internal/keeper/batch.go
+++ b/x/bonds/internal/keeper/batch.go
@@ -678,8 +678,8 @@ func (k Keeper) UpdateAlpha(ctx sdk.Context, bondDid did.Did) {
 		newSystemAlpha = temp1.Mul(temp2)
 	}
 
-	// Check 1 (newSystemAlpha != systemAlpha)
-	if newSystemAlpha.Equal(paramsMap["systemAlpha"]) {
+	// Check 1 (newSystemAlpha != prevSystemAlpha)
+	if newSystemAlpha.Equal(prevSystemAlpha) {
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeEditAlphaFailed,
 			sdk.NewAttribute(types.AttributeKeyBondDid, bond.BondDid),
@@ -689,7 +689,7 @@ func (k Keeper) UpdateAlpha(ctx sdk.Context, bondDid did.Did) {
 		))
 		return
 	}
-	// Check 2 (I > C * systemAlpha)
+	// Check 2 (I > C * newSystemAlpha)
 	if paramsMap["I0"].LTE(newSystemAlpha.MulInt(C)) {
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeEditAlphaFailed,
@@ -700,8 +700,8 @@ func (k Keeper) UpdateAlpha(ctx sdk.Context, bondDid did.Did) {
 		))
 		return
 	}
-	// Check 3 (R / C > newSystemAlpha - systemAlpha)
-	if R.QuoInt(C).LTE(newSystemAlpha.Sub(paramsMap["systemAlpha"])) {
+	// Check 3 (R / C > newSystemAlpha - prevSystemAlpha)
+	if R.QuoInt(C).LTE(newSystemAlpha.Sub(prevSystemAlpha)) {
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeEditAlphaFailed,
 			sdk.NewAttribute(types.AttributeKeyBondDid, bond.BondDid),

--- a/x/bonds/internal/keeper/querier.go
+++ b/x/bonds/internal/keeper/querier.go
@@ -360,23 +360,23 @@ func queryAlphaMaximums(ctx sdk.Context, path []string, keeper Keeper) (res []by
 		return nil, sdkerrors.Wrapf(types.ErrFunctionNotAvailableForFunctionType, bond.FunctionType)
 	}
 
-	var maxAlphaIncrease, maxAlpha sdk.Dec
+	var maxSystemAlphaIncrease, maxSystemAlpha sdk.Dec
 	if len(bond.CurrentReserve) == 0 {
-		maxAlphaIncrease = sdk.ZeroDec()
-		maxAlpha = sdk.ZeroDec()
+		maxSystemAlphaIncrease = sdk.ZeroDec()
+		maxSystemAlpha = sdk.ZeroDec()
 	} else {
 		R := bond.CurrentReserve[0].Amount // common reserve balance
 		C := bond.OutcomePayment
-		maxAlphaIncrease = sdk.NewDecFromInt(R).QuoInt(C)
+		maxSystemAlphaIncrease = sdk.NewDecFromInt(R).QuoInt(C)
 
 		paramsMap := bond.FunctionParameters.AsMap()
 		I := paramsMap["I0"]
-		maxAlpha = I.QuoInt(C)
+		maxSystemAlpha = I.QuoInt(C)
 	}
 
 	var result types.QueryAlphaMaximums
-	result.MaxAlphaIncrease = maxAlphaIncrease
-	result.MaxAlpha = maxAlpha
+	result.MaxSystemAlphaIncrease = maxSystemAlphaIncrease
+	result.MaxSystemAlpha = maxSystemAlpha
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, result)
 	if err != nil {

--- a/x/bonds/internal/types/alpha.go
+++ b/x/bonds/internal/types/alpha.go
@@ -2,6 +2,10 @@ package types
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
+var (
+	StartingPublicAlpha = sdk.MustNewDecFromStr("0.5")
+)
+
 func SystemAlpha(publicAlpha sdk.Dec, S0, S1, R, C sdk.Int) sdk.Dec {
 	// S0/S1: negative and positive attestations, measured in bond tokens
 	// C: outcome payment

--- a/x/bonds/internal/types/alpha.go
+++ b/x/bonds/internal/types/alpha.go
@@ -2,7 +2,7 @@ package types
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
-func Alpha(S0, S1, R, C sdk.Int) sdk.Dec {
+func SystemAlpha(publicAlpha sdk.Dec, S0, S1, R, C sdk.Int) sdk.Dec {
 	// S0/S1: negative and positive attestations, measured in bond tokens
 	// C: outcome payment
 	// R: current reserve
@@ -13,7 +13,7 @@ func Alpha(S0, S1, R, C sdk.Int) sdk.Dec {
 
 	x := sdk.NewDecFromInt(S1R)
 	y := sdk.NewDecFromInt(S1R.Sub(S0R).Add(S0C))
-	return x.Quo(y)
+	return publicAlpha.Mul(x.Quo(y))
 }
 
 func Kappa(I sdk.Dec, C sdk.Int, alpha sdk.Dec) sdk.Dec {

--- a/x/bonds/internal/types/batch.go
+++ b/x/bonds/internal/types/batch.go
@@ -8,7 +8,7 @@ import (
 type Batch struct {
 	BondDid         did.Did      `json:"bond_did" yaml:"bond_did"`
 	BlocksRemaining sdk.Uint     `json:"blocks_remaining" yaml:"blocks_remaining"`
-	NextAlpha       sdk.Dec      `json:"next_alpha" yaml:"next_alpha"`
+	NextPublicAlpha sdk.Dec      `json:"next_public_alpha" yaml:"next_public_alpha"`
 	TotalBuyAmount  sdk.Coin     `json:"total_buy_amount" yaml:"total_buy_amount"`
 	TotalSellAmount sdk.Coin     `json:"total_sell_amount" yaml:"total_sell_amount"`
 	BuyPrices       sdk.DecCoins `json:"buy_prices" yaml:"buy_prices"`
@@ -21,14 +21,14 @@ type Batch struct {
 func (b Batch) MoreBuysThanSells() bool { return b.TotalSellAmount.IsLT(b.TotalBuyAmount) }
 func (b Batch) MoreSellsThanBuys() bool { return b.TotalBuyAmount.IsLT(b.TotalSellAmount) }
 func (b Batch) EqualBuysAndSells() bool { return b.TotalBuyAmount.IsEqual(b.TotalSellAmount) }
-func (b Batch) HasNextAlpha() bool      { return !b.NextAlpha.IsNegative() }
+func (b Batch) HasNextAlpha() bool      { return !b.NextPublicAlpha.IsNegative() }
 func (b Batch) Empty() bool             { return len(b.Buys) == 0 && len(b.Sells) == 0 && len(b.Swaps) == 0 }
 
 func NewBatch(bondDid did.Did, token string, blocks sdk.Uint) Batch {
 	return Batch{
 		BondDid:         bondDid,
 		BlocksRemaining: blocks,
-		NextAlpha:       sdk.OneDec().Neg(),
+		NextPublicAlpha: sdk.OneDec().Neg(),
 		TotalBuyAmount:  sdk.NewInt64Coin(token, 0),
 		TotalSellAmount: sdk.NewInt64Coin(token, 0),
 	}

--- a/x/bonds/internal/types/events.go
+++ b/x/bonds/internal/types/events.go
@@ -54,7 +54,8 @@ const (
 	AttributeKeyNewBondTokenBalance    = "new_bond_token_balance"
 	AttributeKeyOldState               = "old_state"
 	AttributeKeyNewState               = "new_state"
-	AttributeKeyAlpha                  = "alpha"
+	AttributeKeyPublicAlpha            = "public_alpha"
+	AttributeKeySystemAlpha            = "system_alpha"
 
 	AttributeValueBuyOrder  = "buy"
 	AttributeValueSellOrder = "sell"

--- a/x/bonds/internal/types/msgs.go
+++ b/x/bonds/internal/types/msgs.go
@@ -295,9 +295,13 @@ func (msg MsgSetNextAlpha) ValidateBasic() error {
 		return sdkerrors.Wrap(ErrArgumentCannotBeEmpty, "EditorDid")
 	}
 
-	// Check that 0 <= alpha <= 1
-	if msg.Alpha.LT(sdk.ZeroDec()) || msg.Alpha.GT(sdk.OneDec()) {
-		return sdkerrors.Wrap(ErrInvalidAlpha, "0 <= alpha <= 1")
+	// Check that 0.0001 <= alpha <= 0.9999. Note that we cannot set public
+	// alpha to 0 or 1, because these are edge cases which cause the system
+	// alpha to get stuck if we try to change the value of public alpha again.
+	minNextAlpha := sdk.MustNewDecFromStr("0.0001")
+	maxNextAlpha := sdk.MustNewDecFromStr("0.9999")
+	if msg.Alpha.LT(minNextAlpha) || msg.Alpha.GT(maxNextAlpha) {
+		return sdkerrors.Wrap(ErrInvalidAlpha, "0.0001 <= alpha <= 0.9999")
 	}
 
 	// Check that DIDs valid

--- a/x/bonds/internal/types/querier.go
+++ b/x/bonds/internal/types/querier.go
@@ -34,6 +34,6 @@ type QuerySwapReturn struct {
 }
 
 type QueryAlphaMaximums struct {
-	MaxAlphaIncrease sdk.Dec `json:"max_alpha_increase" yaml:"max_alpha_increase"`
-	MaxAlpha         sdk.Dec `json:"max_alpha" yaml:"max_alpha"`
+	MaxSystemAlphaIncrease sdk.Dec `json:"max_system_alpha_increase" yaml:"max_system_alpha_increase"`
+	MaxSystemAlpha         sdk.Dec `json:"max_system_alpha" yaml:"max_system_alpha"`
 }

--- a/x/bonds/spec/03_messages.md
+++ b/x/bonds/spec/03_messages.md
@@ -128,21 +128,23 @@ This message stores the updated `Bond` object.
 
 ## MsgSetNextAlpha
 
-The controller of a bond can set the next alpha value for Augmented Bonding Curve type bonds using `MsgSetNextAlpha`.
+The controller of a bond can set the next public alpha value for Augmented Bonding Curve type bonds using `MsgSetNextAlpha`.
 
 | **Field** | **Type**  | **Description** |
 |:----------|:----------|:----------------|
 | BondDid   | `did.Did` | DID of the bond we are interacting with (e.g. `did:ixo:U7GK8p8rVhJMKhBVRCJJ8c`)
-| Alpha     | `sdk.Dec` | Alpha value to be set (e.g. `0.5`)
+| Alpha     | `sdk.Dec` | Public alpha value to be set (e.g. `0.5`)
 | EditorDid | `did.Did` | DID of the bond editor (e.g. `did:ixo:U7GK8p8rVhJMKhBVRCJJ8c`)
 
 This message is expected to fail if:
 - bond being interacted with does not exist
-- alpha value falls outside of 0.0001 <= alpha <= 0.9999
-- alpha value violates any of the below rules
-  - `newAlpha != alpha`
-  - `I > C * alpha`
-  - `R / C > newAlpha - alpha`
+- public alpha value falls outside of 0.0001 <= alpha <= 0.9999
+- public alpha value violates any of the below rules
+  - `newPublicAlpha != publicAlpha`
+- resultant system alpha value violates any of the below rules
+  - `newSystemAlpha != systemAlpha`
+  - `I > C * systemAlpha`
+  - `R / C > newSystemAlpha - systemAlpha`
 - editor is not the bond controller
 - bond DID or editor DID is not a valid DID
 

--- a/x/bonds/spec/03_messages.md
+++ b/x/bonds/spec/03_messages.md
@@ -138,7 +138,7 @@ The controller of a bond can set the next alpha value for Augmented Bonding Curv
 
 This message is expected to fail if:
 - bond being interacted with does not exist
-- alpha value falls outside of 0 <= alpha <= 1
+- alpha value falls outside of 0.0001 <= alpha <= 0.9999
 - alpha value violates any of the below rules
   - `newAlpha != alpha`
   - `I > C * alpha`


### PR DESCRIPTION
Existing alpha is now 'system' alpha and introduced new 'public' alpha, where the 'system' alpha is now calculated from the 'public' alpha. Note that `MsgSetNextAlpha` now updates the 'public' alpha. The 'system' alpha, rather than being supplied by this message, is now calculated based on the 'public' alpha. The starting 'public' alpha is 0.5, stored in `StartingPublicAlpha`.