### PR TITLE
Removed FlagToken from edit-bond (CLI)

### DIFF
--- a/x/bonds/client/cli/flags.go
+++ b/x/bonds/client/cli/flags.go
@@ -30,15 +30,13 @@ const (
 )
 
 var (
-	fsBondGeneral = flag.NewFlagSet("", flag.ContinueOnError)
-	fsBondCreate  = flag.NewFlagSet("", flag.ContinueOnError)
-	fsBondEdit    = flag.NewFlagSet("", flag.ContinueOnError)
+	fsBondCreate = flag.NewFlagSet("", flag.ContinueOnError)
+	fsBondEdit   = flag.NewFlagSet("", flag.ContinueOnError)
 )
 
 func init() {
 
-	fsBondGeneral.String(FlagToken, "", "The bond's token")
-
+	fsBondCreate.String(FlagToken, "", "The bond's token")
 	fsBondCreate.String(FlagName, "", "The bond's name")
 	fsBondCreate.String(FlagDescription, "", "The bond's description")
 	fsBondCreate.String(FlagFunctionType, "", "The type of function that the bond will be")

--- a/x/bonds/client/cli/tx.go
+++ b/x/bonds/client/cli/tx.go
@@ -155,7 +155,6 @@ func GetCmdCreateBond(cdc *codec.Codec) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().AddFlagSet(fsBondGeneral)
 	cmd.Flags().AddFlagSet(fsBondCreate)
 
 	_ = cmd.MarkFlagRequired(FlagToken)
@@ -208,7 +207,6 @@ func GetCmdEditBond(cdc *codec.Codec) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().AddFlagSet(fsBondGeneral)
 	cmd.Flags().AddFlagSet(fsBondEdit)
 
 	_ = cmd.MarkFlagRequired(FlagBondDid)


### PR DESCRIPTION
@stefaniatadama when you pull from master, you will need to remove `--token` from any call to `edit-bond` from the CLI