### PR TITLE
Fix Gas Estimation

### DIFF
--- a/scripts/demo_gas_estimation.sh
+++ b/scripts/demo_gas_estimation.sh
@@ -19,8 +19,9 @@ if [[ ($RET == Error*) || ($RET == *'"latest_block_height":"0"'*) ]]; then
   wait
 fi
 
-GAS_PRICES="0.025uixo"
 PASSWORD="12345678"
+GAS_PRICES="0.025uixo"
+CHAIN_ID="pandora-2"
 FEE=$(yes $PASSWORD | ixod keys show fee -a)
 
 ixod_tx() {
@@ -30,12 +31,13 @@ ixod_tx() {
   cmd="$1 $2"
   shift
   shift
-  APPROX=$(ixod tx $cmd --gas=auto --gas-adjustment=1.05 --fees=1uixo --dry-run "$@" 2>&1)
+  APPROX=$(ixod tx $cmd --gas=auto --gas-adjustment=1.05 --fees=1uixo --chain-id="$CHAIN_ID" --dry-run "$@" 2>&1)
   APPROX=${APPROX//gas estimate: /}
   echo "Gas estimate: $APPROX"
   ixod tx $cmd \
     --gas="$APPROX" \
     --gas-prices="$GAS_PRICES" \
+    --chain-id="$CHAIN_ID" \
     "$@" | jq .
     # The $@ adds any extra arguments to the end
 }

--- a/x/ixo/types/auth.go
+++ b/x/ixo/types/auth.go
@@ -49,7 +49,7 @@ type PubKeyGetter func(ctx sdk.Context, msg IxoMsg) (cryptotypes.PubKey, error)
 
 func NewDefaultAnteHandler(ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 	sigGasConsumer ante.SignatureVerificationGasConsumer, pubKeyGetter PubKeyGetter,
-	signModeHandler authsigning.SignModeHandler,) sdk.AnteHandler {
+	signModeHandler authsigning.SignModeHandler) sdk.AnteHandler {
 
 	// Refer to inline documentation in app/app.go for introduction to why we
 	// need a custom ixo AnteHandler. Below, we will discuss the differences
@@ -127,7 +127,7 @@ func NewDefaultAnteHandler(ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 //	return signMsg.Fee, nil
 //}
 
-func GenerateOrBroadcastTxCLI(clientCtx client.Context, flagSet *pflag.FlagSet, ixoDid exported.IxoDid, msg sdk.Msg,) error {
+func GenerateOrBroadcastTxCLI(clientCtx client.Context, flagSet *pflag.FlagSet, ixoDid exported.IxoDid, msg sdk.Msg) error {
 	txf := tx.NewFactoryCLI(clientCtx, flagSet)
 	return GenerateOrBroadcastTxWithFactory(clientCtx, txf, ixoDid, msg)
 }
@@ -138,11 +138,6 @@ func GenerateOrBroadcastTxWithFactory(clientCtx client.Context, txf tx.Factory, 
 	}
 
 	return BroadcastTx(clientCtx, txf, ixoDid, msg)
-}
-
-// GasEstimateResponse defines a response definition for tx gas estimation.
-type GasEstimateResponse struct {
-	GasEstimate uint64 `json:"gas_estimate" yaml:"gas_estimate"`
 }
 
 func BroadcastTx(clientCtx client.Context, txf tx.Factory, ixoDid exported.IxoDid, msg sdk.Msg) error {
@@ -158,7 +153,7 @@ func BroadcastTx(clientCtx client.Context, txf tx.Factory, ixoDid exported.IxoDi
 		}
 
 		txf = txf.WithGas(adjusted)
-		_, _ = fmt.Fprintf(os.Stderr, "%s\n", GasEstimateResponse{GasEstimate: txf.Gas()})
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", tx.GasEstimateResponse{GasEstimate: txf.Gas()})
 	}
 
 	if clientCtx.Simulate {


### PR DESCRIPTION
Fixed by using Cosmos SDK's `GasEstimateResponse` type instead of a copy of it. This fixed how the gas estimate is output to the CLI. I think it's just because on our side we did not have the `String()` function, and so the response was being output as an object.

I've also fixed the gas estimate script :)