### PR TITLE
added dockerfile for official builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.19.4 as build
+
+WORKDIR /app
+
+COPY . .
+
+RUN make build
+
+FROM gcr.io/distroless/base-debian11 as run
+
+COPY --from=build /app/build/ixod /bin/ixod
+COPY --from=build /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v1.1.1/internal/api/ /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v1.1.1/internal/api/
+copy --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+
+ENV HOME /ixo
+WORKDIR $HOME
+
+EXPOSE 26656
+EXPOSE 26657
+EXPOSE 1317
+EXPOSE 9090
+EXPOSE 26660
+
+ENTRYPOINT [ "ixod" ]


### PR DESCRIPTION
Dockerfile includes fix for
ERR: libwasmvm.x86_64.so: cannot open shared object file: No such file or directory when not running inside the same image as was built and libgcc_s.so.1: cannot open shared object file: No such file or directory a dependency that isn't available inside of distroless image. https://github.com/GoogleContainerTools/distroless

